### PR TITLE
Lock subsystem respec, expanded test coverage, and GitHub Actions CI

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -1,0 +1,230 @@
+name: Regression Tests
+
+on:
+  push:
+    branches:
+      - master
+      - 'release/**'
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+    inputs:
+      batch:
+        description: 'Batch name to run (leave blank to run all)'
+        required: false
+        type: string
+        default: ''
+
+jobs:
+
+  # ─── Build ────────────────────────────────────────────────────────────────────
+  # Compiles the solution once, then bundles the test binaries, run settings, and
+  # DB init SQL into a single artifact consumed by every parallel test job.
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Build (net9.0)
+        run: dotnet build NEsperAll.sln --configuration Release --framework net9.0
+
+      - name: Stage artifact
+        run: |
+          mkdir -p staging/bin
+          cp -r tst/NEsper.Regression.Runner/bin/Release/net9.0/. staging/bin/
+          cp NEsper.runsettings staging/
+          cp tst/etc/regression/create_testdb_pgsql.sql staging/
+
+      - name: Upload test artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-binaries
+          path: staging/
+          retention-days: 1
+
+
+  # ─── Test matrix ──────────────────────────────────────────────────────────────
+  # Each batch runs in its own job against the shared build artifact.
+  # Postgres is always present — conditional service containers aren't supported
+  # by GitHub Actions, and the startup cost is negligible on non-DB batches.
+  test:
+    name: "${{ matrix.batch }}"
+    needs: build
+    runs-on: ubuntu-latest
+
+    # For workflow_dispatch: skip jobs that don't match the requested batch.
+    # Push/PR events always run all batches.
+    if: >
+      github.event_name != 'workflow_dispatch' ||
+      inputs.batch == '' ||
+      inputs.batch == matrix.batch
+
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_DB: esper
+          POSTGRES_USER: esper
+          POSTGRES_PASSWORD: 3sp3rP@ssw0rd
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    strategy:
+      fail-fast: false   # don't cancel siblings on first failure
+      matrix:
+        include:
+          - batch: Client
+            filter: TestClient
+            requires_db: false
+            timeout_minutes: 10
+          - batch: Context
+            filter: TestContext
+            requires_db: true
+            timeout_minutes: 20
+          - batch: EPL-Database
+            filter: TestEPLDatabase
+            requires_db: true
+            timeout_minutes: 10
+          - batch: EPL-Dataflow
+            filter: TestEPLDataflow
+            requires_db: false
+            timeout_minutes: 20
+          - batch: EPL-FromClause
+            filter: TestEPLFromClauseMethod
+            requires_db: false
+            timeout_minutes: 10
+          - batch: EPL-Join
+            filter: TestEPLJoin
+            requires_db: false
+            timeout_minutes: 20
+          - batch: EPL-Other
+            filter: TestEPLOther
+            requires_db: false
+            timeout_minutes: 20
+          - batch: EPL-Subselect
+            filter: TestEPLSubselect
+            requires_db: false
+            timeout_minutes: 20
+          - batch: Event
+            filter: TestEvent
+            requires_db: false
+            timeout_minutes: 20
+          - batch: Expression
+            filter: TestExpr
+            requires_db: false
+            timeout_minutes: 20
+          - batch: Infrastructure
+            filter: TestInfra
+            requires_db: false
+            timeout_minutes: 20
+          - batch: Multithread
+            filter: TestMultithreaded
+            requires_db: true
+            timeout_minutes: 10
+          - batch: Pattern
+            filter: TestPattern
+            requires_db: false
+            timeout_minutes: 20
+          - batch: ResultSet
+            filter: TestResultSet
+            requires_db: false
+            timeout_minutes: 20
+          - batch: RowRecognition
+            filter: TestRowRecog
+            requires_db: false
+            timeout_minutes: 20
+          - batch: View
+            filter: TestView
+            requires_db: false
+            timeout_minutes: 20
+
+    steps:
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Download test artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: test-binaries
+          path: artifact
+
+      # psql is pre-installed on ubuntu-latest; this step is a no-op on non-DB batches.
+      - name: Initialize database
+        if: matrix.requires_db
+        env:
+          PGPASSWORD: 3sp3rP@ssw0rd
+        run: psql -h localhost -U esper -d esper -f artifact/create_testdb_pgsql.sql
+
+      - name: Run tests — ${{ matrix.batch }}
+        timeout-minutes: ${{ matrix.timeout_minutes }}
+        run: |
+          dotnet test artifact/bin/NEsper.Regression.Runner.dll \
+            --settings artifact/NEsper.runsettings \
+            --filter "${{ matrix.filter }}" \
+            --logger "console;verbosity=normal" \
+            --logger "trx;LogFileName=${{ github.workspace }}/TestResults/${{ matrix.batch }}.trx"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.batch }}
+          path: TestResults/${{ matrix.batch }}.trx
+          retention-days: 7
+
+
+  # ─── Report ───────────────────────────────────────────────────────────────────
+  # Collects all TRX files, publishes a rich summary to the PR/commit, and fails
+  # the check if any batch failed. Add this job as the required status check on
+  # master branch protection (Settings → Branches → require "Report" to pass).
+  report:
+    name: Report
+    needs: test
+    runs-on: ubuntu-latest
+    if: always()
+
+    steps:
+      - name: Download all test results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: test-results-*
+          merge-multiple: true
+          path: TestResults
+
+      - name: Publish test report
+        uses: dorny/test-reporter@v1
+        with:
+          name: Regression Test Results
+          path: 'TestResults/*.trx'
+          reporter: dotnet-trx
+          fail-on-error: true
+
+      - name: Fail if any batch failed
+        if: needs.test.result != 'success'
+        run: |
+          echo "One or more test batches failed. See the test report above for details."
+          exit 1

--- a/examples/NEsper.Benchmark/NEsper.Benchmark.Server/ThreadPoolExecutor.cs
+++ b/examples/NEsper.Benchmark/NEsper.Benchmark.Server/ThreadPoolExecutor.cs
@@ -27,7 +27,7 @@ namespace NEsper.Benchmark.Server
         {
             _maxSize = maxQueueSize ?? int.MaxValue;
             _eventQueueDepth = 0;
-            _eventMonitor = new MonitorSpinLock(60000);
+            _eventMonitor = new MonitorSlimLock(60000);
             _isHandlingEvents = true;
         }
 

--- a/run-test-batches.ps1
+++ b/run-test-batches.ps1
@@ -19,7 +19,7 @@
     Show configuration summary without running tests
 .EXAMPLE
     .\run-test-batches.ps1
-    Runs all enabled batches
+    Runs all enabled batches; TRX results saved under TestResults\<timestamp>\
 .EXAMPLE
     .\run-test-batches.ps1 -BatchName "EPL-Database"
     Runs only the EPL-Database batch
@@ -121,6 +121,10 @@ $results = @{
 }
 
 $startTime = Get-Date
+$runTimestamp = $startTime.ToString("yyyy-MM-dd_HH-mm-ss")
+$testResultsDir = Join-Path $PSScriptRoot "TestResults\$runTimestamp"
+New-Item -ItemType Directory -Path $testResultsDir -Force | Out-Null
+Write-Info "Test results directory: $testResultsDir"
 
 # Run isolated tests if requested
 if ($IsolatedOnly) {
@@ -138,12 +142,14 @@ if ($IsolatedOnly) {
         $timeout = $test.timeout
         $filter = $test.filter
 
+        $trxFile = Join-Path $testResultsDir "$($test.name).trx"
         $testArgs = @(
             "test",
             "--filter", $filter,
             "--framework", $targetFramework,
             "--settings", $runSettings,
-            "--logger", "console;verbosity=normal"
+            "--logger", "console;verbosity=normal",
+            "--logger", "trx;LogFileName=$trxFile"
         )
 
         $testResult = & dotnet @testArgs
@@ -164,6 +170,8 @@ if ($IsolatedOnly) {
     Write-Info "Total: $($results.Total)"
     Write-Success "Passed: $($results.Passed)"
     Write-Failure "Failed: $($results.Failed)"
+    Write-Info ""
+    Write-Info "TRX results: $testResultsDir"
 
     exit $(if ($results.Failed -gt 0) { 1 } else { 0 })
 }
@@ -200,17 +208,16 @@ try {
         $batchStartTime = Get-Date
 
         # Build test arguments
+        $consoleVerbosity = if ($Verbose) { "console;verbosity=detailed" } else { "console;verbosity=normal" }
+        $trxFile = Join-Path $testResultsDir "$($batch.name).trx"
         $testArgs = @(
             "test",
             "--filter", $batch.filter,
             "--framework", $targetFramework,
             "--settings", "../../$runSettings",
-            "--logger", "console;verbosity=normal"
+            "--logger", $consoleVerbosity,
+            "--logger", "trx;LogFileName=$trxFile"
         )
-
-        if ($Verbose) {
-            $testArgs[-1] = "console;verbosity=detailed"
-        }
 
         # Run the tests
         Write-Info "Executing: dotnet $($testArgs -join ' ')"
@@ -279,6 +286,25 @@ try {
         Write-Info ""
         Write-Warning "Note: $($config.knownFailures.failures.Count) known failure(s) documented in configuration"
     }
+
+    Write-Info ""
+    Write-Info "TRX results: $testResultsDir"
+
+    # Write summary.txt so the run is reviewable after the terminal closes
+    $summaryLines = @(
+        "NEsper Test Run Summary",
+        "Run:       $runTimestamp",
+        "Framework: $targetFramework",
+        "Duration:  $('{0:N2}' -f $totalDuration)s",
+        "Batches:   $($results.Total) total, $($results.Passed) passed, $($results.Failed) failed",
+        "",
+        "Batch Results:"
+    )
+    foreach ($result in $results.BatchResults) {
+        $status = if ($result.Success) { "PASS" } else { "FAIL" }
+        $summaryLines += "  [$status] $($result.Name) ($('{0:N2}' -f $result.Duration)s)"
+    }
+    $summaryLines | Set-Content (Join-Path $testResultsDir "summary.txt")
 
     # Exit with appropriate code
     exit $(if ($results.Failed -gt 0) { 1 } else { 0 })

--- a/src/NEsper.Common/common/internal/context/util/StatementCPCacheService.cs
+++ b/src/NEsper.Common/common/internal/context/util/StatementCPCacheService.cs
@@ -23,7 +23,7 @@ namespace com.espertech.esper.common.@internal.context.util
     {
         public const int DEFAULT_AGENT_INSTANCE_ID = -1;
 
-        private readonly ILockable @lock = new MonitorSpinLock(60000);
+        private readonly ILockable @lock = new MonitorSlimLock(60000);
 
         /* for expression resources under context partitioning */
         private readonly StatementAIResourceRegistry statementAgentInstanceRegistry;

--- a/src/NEsper.Common/common/internal/util/ManagedReadWriteLock.cs
+++ b/src/NEsper.Common/common/internal/util/ManagedReadWriteLock.cs
@@ -67,7 +67,7 @@ namespace com.espertech.esper.common.@internal.util
             _name = name;
             Lock = isFair
                 ? new FairReaderWriterLock(LockConstants.DefaultTimeout)
-                : (IReaderWriterLock)new StandardReaderWriterLock(LockConstants.DefaultTimeout);
+                : (IReaderWriterLock)new SlimReaderWriterLock(LockConstants.DefaultTimeout);
         }
 
         public void Dispose()

--- a/src/NEsper.Compat/compat/TrackedDisposable.cs
+++ b/src/NEsper.Compat/compat/TrackedDisposable.cs
@@ -7,12 +7,13 @@
 ///////////////////////////////////////////////////////////////////////////////////////
 
 using System;
+using System.Threading;
 
 namespace com.espertech.esper.compat
 {
     public sealed class TrackedDisposable : IDisposable
     {
-        private readonly Action _actionOnDispose;
+        private Action _actionOnDispose;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TrackedDisposable"/> class.
@@ -28,7 +29,7 @@ namespace com.espertech.esper.compat
         /// </summary>
         public void Dispose()
         {
-            _actionOnDispose.Invoke();
+            Interlocked.Exchange(ref _actionOnDispose, null)?.Invoke();
         }
     }
 }

--- a/src/NEsper.Compat/compat/collections/BoundBlockingQueue.cs
+++ b/src/NEsper.Compat/compat/collections/BoundBlockingQueue.cs
@@ -30,7 +30,7 @@ namespace com.espertech.esper.compat.collections
         public BoundBlockingQueue(int maxCapacity, int lockTimeout)
         {
             _queue = new LinkedList<T>();
-            _queueLock = new MonitorSpinLock(lockTimeout);
+            _queueLock = new MonitorSlimLock(lockTimeout);
             _queuePopWaitHandle = new AutoResetEvent(false);
             _queuePushWaitHandle = new AutoResetEvent(false);
             _maxCapacity = maxCapacity;

--- a/src/NEsper.Compat/compat/magic/MagicMarker.cs
+++ b/src/NEsper.Compat/compat/magic/MagicMarker.cs
@@ -40,7 +40,7 @@ namespace com.espertech.esper.compat.magic
         }
 
         #region Collection Factory
-        private readonly ILockable _collectionFactoryTableLock = new MonitorSpinLock(60000);
+        private readonly ILockable _collectionFactoryTableLock = new MonitorSlimLock(60000);
         private readonly IDictionary<Type, Func<object, ICollection<object>>> _collectionFactoryTable =
             new Dictionary<Type, Func<object, ICollection<object>>>();
 
@@ -112,7 +112,7 @@ namespace com.espertech.esper.compat.magic
         #endregion
 
         #region List Factory
-        private readonly ILockable _listFactoryTableLock = new MonitorSpinLock(60000);
+        private readonly ILockable _listFactoryTableLock = new MonitorSlimLock(60000);
         private readonly IDictionary<Type, Func<object, IList<object>>> _listFactoryTable =
             new Dictionary<Type, Func<object, IList<object>>>();
 
@@ -177,7 +177,7 @@ namespace com.espertech.esper.compat.magic
         #endregion
 
         #region Dictionary Factory
-        private readonly ILockable _dictionaryFactoryTableLock = new MonitorSpinLock(60000);
+        private readonly ILockable _dictionaryFactoryTableLock = new MonitorSlimLock(60000);
         private readonly IDictionary<Type, Func<object, IDictionary<object, object>>> _dictionaryFactoryTable =
             new Dictionary<Type, Func<object, IDictionary<object, object>>>();
 
@@ -244,7 +244,7 @@ namespace com.espertech.esper.compat.magic
         #endregion
 
         #region String Dictionary Factory
-        private readonly ILockable _stringDictionaryFactoryTableLock = new MonitorSpinLock(60000);
+        private readonly ILockable _stringDictionaryFactoryTableLock = new MonitorSlimLock(60000);
         private readonly IDictionary<Type, Func<object, IDictionary<string, object>>> _stringDictionaryFactoryTable =
             new Dictionary<Type, Func<object, IDictionary<string, object>>>();
 

--- a/src/NEsper.Compat/compat/magic/MagicStringDictionaryExtensions.cs
+++ b/src/NEsper.Compat/compat/magic/MagicStringDictionaryExtensions.cs
@@ -9,7 +9,7 @@ namespace com.espertech.esper.compat.magic
 {
     public static class MagicStringDictionaryExtensions
     {
-        private static readonly ILockable FunctionalAtomTableLock = new MonitorSpinLock(60000);
+        private static readonly ILockable FunctionalAtomTableLock = new MonitorSlimLock(60000);
 
         private static readonly IDictionary<Type, FunctionalAtom> FunctionalAtomTable =
             new Dictionary<Type, FunctionalAtom>();

--- a/src/NEsper.Compat/compat/magic/MagicType.cs
+++ b/src/NEsper.Compat/compat/magic/MagicType.cs
@@ -728,7 +728,7 @@ namespace com.espertech.esper.compat.magic
             return genericTypeCaster(value);
         }
 
-        private static readonly ILockable TypeCacheLock = new MonitorSpinLock(60000);
+        private static readonly ILockable TypeCacheLock = new MonitorSlimLock(60000);
 
         private static readonly Dictionary<Type, MagicType> TypeCacheTable =
             new Dictionary<Type, MagicType>();
@@ -750,7 +750,7 @@ namespace com.espertech.esper.compat.magic
             }
         }
 
-        private static readonly ILockable AccessorCacheLock = new MonitorSpinLock(60000);
+        private static readonly ILockable AccessorCacheLock = new MonitorSlimLock(60000);
 
         private static readonly Dictionary<MethodInfo, Func<object, object>> AccessorCacheTable =
             new Dictionary<MethodInfo, Func<object, object>>();

--- a/src/NEsper.Compat/compat/threading/locks/CommonReadLock.cs
+++ b/src/NEsper.Compat/compat/threading/locks/CommonReadLock.cs
@@ -6,34 +6,25 @@ namespace com.espertech.esper.compat.threading.locks
 	/// <summary>
 	/// Description of CommonReadLock.
 	/// </summary>
-	public sealed class CommonReadLock 
+	public sealed class CommonReadLock
         : ILockable
 	{
 	    private readonly int _lockTimeout;
         private readonly IReaderWriterLockCommon _lockObj;
-	    private readonly IDisposable _disposableObj;
 
         public IDisposable Acquire()
         {
             _lockObj.AcquireReaderLock(_lockTimeout);
-            return _disposableObj;
+            return new TrackedDisposable(_lockObj.ReleaseReaderLock);
         }
 
 	    public IDisposable Acquire(long msec)
 	    {
             _lockObj.AcquireReaderLock(msec);
-            return _disposableObj;
+            return new TrackedDisposable(_lockObj.ReleaseReaderLock);
         }
 
-        public IDisposable Acquire(bool releaseLock, long? msec = null)
-        {
-            _lockObj.AcquireReaderLock(msec ?? _lockTimeout);
-            if (releaseLock)
-                return _disposableObj;
-            return new VoidDisposable();
-        }
-
-	    public IDisposable ReleaseAcquire()
+        public IDisposable ReleaseAcquire()
         {
             _lockObj.ReleaseReaderLock();
             return new TrackedDisposable(() => _lockObj.AcquireReaderLock(_lockTimeout));
@@ -48,7 +39,6 @@ namespace com.espertech.esper.compat.threading.locks
         {
             _lockObj = lockObj;
             _lockTimeout = lockTimeout;
-            _disposableObj = new TrackedDisposable(_lockObj.ReleaseReaderLock);
         }
 	}
 	
@@ -72,14 +62,6 @@ namespace com.espertech.esper.compat.threading.locks
             _lockValue = _lockObj.AcquireReaderLock(msec);
             return new TrackedDisposable(() => _lockObj.ReleaseReaderLock(_lockValue));
         }
-
-	    public IDisposable Acquire(bool releaseLock, long? msec = null)
-	    {
-            _lockValue = _lockObj.AcquireReaderLock(msec ?? _lockTimeout);
-            if (releaseLock)
-                return new TrackedDisposable(() => _lockObj.ReleaseReaderLock(_lockValue));
-	        return new VoidDisposable();
-	    }
 
 	    public IDisposable ReleaseAcquire()
         {

--- a/src/NEsper.Compat/compat/threading/locks/CommonWriteLock.cs
+++ b/src/NEsper.Compat/compat/threading/locks/CommonWriteLock.cs
@@ -14,22 +14,14 @@ namespace com.espertech.esper.compat.threading.locks
         public IDisposable Acquire()
         {
             _lockObj.AcquireWriterLock(_lockTimeout);
-            return new TrackedDisposable(() => _lockObj.ReleaseWriterLock());
+            return new TrackedDisposable(_lockObj.ReleaseWriterLock);
         }
 
 	    public IDisposable Acquire(long msec)
 	    {
             _lockObj.AcquireWriterLock(msec);
-            return new TrackedDisposable(() => _lockObj.ReleaseWriterLock());
+            return new TrackedDisposable(_lockObj.ReleaseWriterLock);
         }
-
-	    public IDisposable Acquire(bool releaseLock, long? msec = null)
-	    {
-            _lockObj.AcquireWriterLock(msec ?? _lockTimeout);
-            if (releaseLock)
-                return new TrackedDisposable(() => _lockObj.ReleaseWriterLock());
-            return new VoidDisposable();
-	    }
 
 	    public IDisposable ReleaseAcquire()
         {
@@ -68,14 +60,6 @@ namespace com.espertech.esper.compat.threading.locks
 	    {
             _lockValue = _lockObj.AcquireWriterLock(msec);
             return new TrackedDisposable(() => _lockObj.ReleaseWriterLock(_lockValue));
-        }
-
-        public IDisposable Acquire(bool releaseLock, long? msec = null)
-        {
-            _lockValue = _lockObj.AcquireWriterLock(msec ?? _lockTimeout);
-            if (releaseLock)
-                return new TrackedDisposable(() => _lockObj.ReleaseWriterLock(_lockValue));
-            return new VoidDisposable();
         }
 
 	    public IDisposable ReleaseAcquire()

--- a/src/NEsper.Compat/compat/threading/locks/DefaultLockManager.cs
+++ b/src/NEsper.Compat/compat/threading/locks/DefaultLockManager.cs
@@ -144,7 +144,7 @@ namespace com.espertech.esper.compat.threading.locks
         {
             var lockFactory = DefaultLockFactory;
             if (lockFactory == null) {
-                throw new ApplicationException("default lock factory is not set");
+                throw new InvalidOperationException("default lock factory is not set");
             }
 
             return WrapLock(lockFactory.Invoke(DefaultLockTimeout));

--- a/src/NEsper.Compat/compat/threading/locks/DefaultReaderWriterLockManager.cs
+++ b/src/NEsper.Compat/compat/threading/locks/DefaultReaderWriterLockManager.cs
@@ -184,7 +184,7 @@ namespace com.espertech.esper.compat.threading.locks
         {
             var lockFactory = DefaultLockFactory;
             if (lockFactory == null) {
-                throw new ApplicationException("default lock factory is not set");
+                throw new InvalidOperationException("default lock factory is not set");
             }
 
             return WrapLock(lockFactory.Invoke(DefaultLockTimeout), category);

--- a/src/NEsper.Compat/compat/threading/locks/FairReaderWriterLock.cs
+++ b/src/NEsper.Compat/compat/threading/locks/FairReaderWriterLock.cs
@@ -88,23 +88,9 @@ namespace com.espertech.esper.compat.threading.locks
         /// <value>
         /// The is writer lock held.
         /// </value>
-        public bool IsWriterLockHeld
-        {
-            get
-            {
-                var hasWriteLock = new bool[] { false };
-
-                WithMainLock(
-                    () =>
-                    {
-                        hasWriteLock[0] =
-                            (_uLockOwner == System.Threading.Thread.CurrentThread.ManagedThreadId) &&
-                            ((_uLockFlags & LockFlags.Exclusive) == LockFlags.Exclusive);
-                    });
-
-                return hasWriteLock[0];
-            }
-        }
+        public bool IsWriterLockHeld => WithMainLock(() =>
+            _uLockOwner == System.Threading.Thread.CurrentThread.ManagedThreadId &&
+            (_uLockFlags & LockFlags.Exclusive) == LockFlags.Exclusive);
 
 #if DEBUG
         /// <summary>
@@ -113,6 +99,26 @@ namespace com.espertech.esper.compat.threading.locks
         /// <value><c>true</c> if TRACE; otherwise, <c>false</c>.</value>
         public bool Trace { get; set; }
 #endif
+
+        /// <summary>
+        /// Executes the action within the mainlock and returns its result.
+        /// </summary>
+        private T WithMainLock<T>(Func<T> action)
+        {
+            var lockTaken = false;
+            try
+            {
+                _uMainLock.Enter(ref lockTaken);
+                if (lockTaken)
+                    return action();
+                throw new TimeoutException("unable to secure main lock");
+            }
+            finally
+            {
+                if (lockTaken)
+                    _uMainLock.Exit();
+            }
+        }
 
         /// <summary>
         /// Executes the action within the mainlock.
@@ -198,6 +204,7 @@ namespace com.espertech.esper.compat.threading.locks
                             (_uLockFlags == LockFlags.Shared))
                         {
                             _uSharedCount++;
+                            _uLockFlags |= LockFlags.Shared;
                             return true;
                         }
 
@@ -211,6 +218,8 @@ namespace com.espertech.esper.compat.threading.locks
                 SlimLock.SmartWait(++ii);
 
                 timeCur = DateTimeHelper.CurrentTimeMillis;
+                if (timeCur >= timeEnd)
+                    throw new TimeoutException("FairReaderWriterLock timeout expired");
             }
         }
 
@@ -267,6 +276,8 @@ namespace com.espertech.esper.compat.threading.locks
                     SlimLock.SmartWait(++ii);
 
                     timeCur = DateTimeHelper.CurrentTimeMillis;
+                    if (timeCur >= timeEnd)
+                        throw new TimeoutException("FairReaderWriterLock timeout expired");
                 }
             }
             finally

--- a/src/NEsper.Compat/compat/threading/locks/FifoReaderWriterLock.cs
+++ b/src/NEsper.Compat/compat/threading/locks/FifoReaderWriterLock.cs
@@ -137,8 +137,7 @@ namespace com.espertech.esper.compat.threading.locks
 	    /// <param name="timeout">The timeout.</param>
 	    public Node AcquireReaderLock(long timeout)
         {
-            var timeCur = DateTimeHelper.CurrentTimeMillis;
-            var timeEnd = timeCur + timeout;
+            var timeEnd = DateTimeHelper.CurrentTimeMillis + timeout;
 
             var curr = _rnode;
             var node = PushNode(new Node(NodeFlags.Shared));
@@ -161,8 +160,10 @@ namespace com.espertech.esper.compat.threading.locks
 					node.ChainLength++;
 #endif
             	} else if (curr.Flags == NodeFlags.Exclusive) {
-                    SlimLock.SmartWait(++iter);
+                    if (!SlimLock.SmartWait(++iter, timeEnd))
+                        throw new TimeoutException("FifoReaderWriterLock timeout expired");
                 } else if (curr.Flags == NodeFlags.None) {
+            		TryAdvancePastDeadNode(curr);
             		curr = curr.Next; // dead node
 #if STATISTICS
 					node.ChainLength++;
@@ -179,8 +180,7 @@ namespace com.espertech.esper.compat.threading.locks
 	    /// <param name="timeout">The timeout.</param>
 	    public Node AcquireWriterLock(long timeout)
         {
-        	var timeCur = DateTimeHelper.CurrentTimeMillis;
-            var timeEnd = timeCur + timeout;
+            var timeEnd = DateTimeHelper.CurrentTimeMillis + timeout;
 
             var curr = _rnode;
             var node = PushNode(new Node(NodeFlags.Exclusive));
@@ -198,11 +198,14 @@ namespace com.espertech.esper.compat.threading.locks
 #endif
             		return _rnode = node;
             	} else if (curr.Flags == NodeFlags.Shared) {
-                    SlimLock.SmartWait(++iter);
+                    if (!SlimLock.SmartWait(++iter, timeEnd))
+                        throw new TimeoutException("FifoReaderWriterLock timeout expired");
             	} else if (curr.Flags == NodeFlags.Exclusive) {
-                    SlimLock.SmartWait(++iter);
+                    if (!SlimLock.SmartWait(++iter, timeEnd))
+                        throw new TimeoutException("FifoReaderWriterLock timeout expired");
                 } else if (curr.Flags == NodeFlags.None) {
             		iter = 0; // clear wait cycling
+                    TryAdvancePastDeadNode(curr);
             		curr = curr.Next; // dead node
 #if STATISTICS
 					node.ChainLength++;
@@ -211,6 +214,17 @@ namespace com.espertech.esper.compat.threading.locks
             		throw new IllegalStateException();
             	}
             }
+        }
+
+        /// <summary>
+        /// Attempts to swing _rnode forward past a dead node, freeing it for GC.
+        /// </summary>
+        private void TryAdvancePastDeadNode(Node deadNode)
+        {
+            var next = deadNode.Next;
+            if (next != null) {
+                Interlocked.CompareExchange(ref _rnode, next, deadNode);
+        }
         }
 
         /// <summary>

--- a/src/NEsper.Compat/compat/threading/locks/ILockable.cs
+++ b/src/NEsper.Compat/compat/threading/locks/ILockable.cs
@@ -24,16 +24,6 @@ namespace com.espertech.esper.compat.threading.locks
         IDisposable Acquire();
 
         /// <summary>
-        /// Acquire the lock; the lock is released when the disposable
-        /// object that was returned is disposed IF the releaseLock
-        /// flag is set.
-        /// </summary>
-        /// <param name="releaseLock"></param>
-        /// <param name="msec"></param>
-        /// <returns></returns>
-        IDisposable Acquire(bool releaseLock, long? msec = null);
-
-        /// <summary>
         /// Acquires the specified msec.
         /// </summary>
         /// <param name="msec">The msec.</param>

--- a/src/NEsper.Compat/compat/threading/locks/MonitorLock.cs
+++ b/src/NEsper.Compat/compat/threading/locks/MonitorLock.cs
@@ -140,22 +140,6 @@ namespace com.espertech.esper.compat.threading.locks
             return new TrackedDisposable(InternalRelease);
         }
 
-        /// <summary>
-        /// Acquire the lock; the lock is released when the disposable
-        /// object that was returned is disposed IF the releaseLock
-        /// flag is set.
-        /// </summary>
-        /// <param name="releaseLock"></param>
-        /// <param name="msec"></param>
-        /// <returns></returns>
-        public IDisposable Acquire(bool releaseLock, long? msec = null)
-        {
-            InternalAcquire((int) (msec ?? _uLockTimeout));
-            if (releaseLock)
-                return new TrackedDisposable(InternalRelease);
-            return new VoidDisposable();
-        }
-
         public IDisposable ReleaseAcquire()
         {
             InternalRelease();
@@ -192,7 +176,7 @@ namespace com.espertech.esper.compat.threading.locks
                 }
                 else
                 {
-                    throw new ApplicationException("Unable to obtain lock before timeout occurred");
+                    throw new TimeoutException("Unable to obtain lock before timeout occurred");
                 }
             }
         }

--- a/src/NEsper.Compat/compat/threading/locks/MonitorSlimLock.cs
+++ b/src/NEsper.Compat/compat/threading/locks/MonitorSlimLock.cs
@@ -96,22 +96,6 @@ namespace com.espertech.esper.compat.threading.locks
         }
 
         /// <summary>
-        /// Acquire the lock; the lock is released when the disposable
-        /// object that was returned is disposed IF the releaseLock
-        /// flag is set.
-        /// </summary>
-        /// <param name="releaseLock"></param>
-        /// <param name="msec"></param>
-        /// <returns></returns>
-        public IDisposable Acquire(bool releaseLock, long? msec = null)
-        {
-            InternalAcquire((int)(msec ?? _uLockTimeout));
-            if (releaseLock)
-                return new TrackedDisposable(InternalRelease);
-            return new VoidDisposable();
-        }
-
-        /// <summary>
         /// Provides a temporary release of the lock if it is acquired.  When the
         /// disposable object that is returned is disposed, the lock is re-acquired.
         /// This method is effectively the opposite of acquire.

--- a/src/NEsper.Compat/compat/threading/locks/MonitorSpinLock.cs
+++ b/src/NEsper.Compat/compat/threading/locks/MonitorSpinLock.cs
@@ -11,6 +11,7 @@ using System.Threading;
 
 namespace com.espertech.esper.compat.threading.locks
 {
+    [Obsolete("MonitorSpinLock busy-spins on a CPU core for the full lock timeout duration under contention. Use MonitorLock for general-purpose locking or MonitorSlimLock for short-duration critical sections.")]
     public class MonitorSpinLock : ILockable
     {
         /// <summary>
@@ -90,22 +91,6 @@ namespace com.espertech.esper.compat.threading.locks
         {
             InternalAcquire((int) msec);
             return new TrackedDisposable(InternalRelease);
-        }
-
-        /// <summary>
-        /// Acquire the lock; the lock is released when the disposable
-        /// object that was returned is disposed IF the releaseLock
-        /// flag is set.
-        /// </summary>
-        /// <param name="releaseLock"></param>
-        /// <param name="msec"></param>
-        /// <returns></returns>
-        public IDisposable Acquire(bool releaseLock, long? msec = null)
-        {
-            InternalAcquire((int) (msec ?? _uLockTimeout));
-            if (releaseLock)
-                return new TrackedDisposable(InternalRelease);
-            return new VoidDisposable();
         }
 
         /// <summary>

--- a/src/NEsper.Compat/compat/threading/locks/SlimReaderWriterLock.cs
+++ b/src/NEsper.Compat/compat/threading/locks/SlimReaderWriterLock.cs
@@ -31,8 +31,6 @@ namespace com.espertech.esper.compat.threading.locks
             ReadLock = new CommonReadLock(this, _lockTimeout);
             WriteLock = new CommonWriteLock(this, _lockTimeout);
 
-            _rDisposable = new TrackedDisposable(ReleaseReaderLock);
-            _wDisposable = new TrackedDisposable(ReleaseWriterLock);
         }
 
         /// <summary>
@@ -54,69 +52,35 @@ namespace com.espertech.esper.compat.threading.locks
         /// <value></value>
         public ILockable WriteLock { get;  private set; }
 
-        private readonly IDisposable _rDisposable;
-        private readonly IDisposable _wDisposable;
-
         public IDisposable AcquireReadLock()
         {
-#if DIAGNOSTICS && DEBUG
-            Console.WriteLine("{0}:AcquireReadLock:IN:{1}: {2}", Thread.CurrentThread.ManagedThreadId, _id, _lockTimeout);
-#endif
-            try {
-                if (_useUpgradeableLocks) {
-                    if (_rwLock.TryEnterUpgradeableReadLock(_lockTimeout)) {
-                        return _rDisposable;
-                    }
-                }
-                else if (_rwLock.TryEnterReadLock(_lockTimeout)) {
-                    return _rDisposable;
+            if (_useUpgradeableLocks) {
+                if (_rwLock.TryEnterUpgradeableReadLock(_lockTimeout)) {
+                    return new TrackedDisposable(ReleaseReaderLock);
                 }
             }
-            finally {
-#if DIAGNOSTICS && DEBUG
-                Console.WriteLine("{0}:AcquireReadLock:OUT:{1}: {2}", Thread.CurrentThread.ManagedThreadId, _id, _lockTimeout);
-#endif
+            else if (_rwLock.TryEnterReadLock(_lockTimeout)) {
+                return new TrackedDisposable(ReleaseReaderLock);
             }
 
-#if DIAGNOSTICS && DEBUG
-            Console.WriteLine("{0}:AcquireReadLock:ERR:{1}: {2}", Thread.CurrentThread.ManagedThreadId, _id, _lockTimeout);
-#endif
             throw new TimeoutException("ReaderWriterLock timeout expired");
         }
 
         public IDisposable AcquireWriteLock()
         {
-#if DIAGNOSTICS && DEBUG
-            Console.WriteLine("{0}:AcquireWriteLock:IN:{1}: {2}", Thread.CurrentThread.ManagedThreadId, _id, _lockTimeout);
-#endif
             if (_rwLock.TryEnterWriteLock(_lockTimeout)) {
-#if DIAGNOSTICS && DEBUG
-                Console.WriteLine("{0}:AcquireWriteLock:OUT:{1}: {2}", Thread.CurrentThread.ManagedThreadId, _id, _lockTimeout);
-#endif
-                return _wDisposable;
+                return new TrackedDisposable(ReleaseWriterLock);
             }
 
-#if DIAGNOSTICS && DEBUG
-            Console.WriteLine("{0}:AcquireWriteLock:ERR:{1}: {2}", Thread.CurrentThread.ManagedThreadId, _id, _lockTimeout);
-#endif
             throw new TimeoutException("ReaderWriterLock timeout expired");
         }
 
         public IDisposable AcquireWriteLock(TimeSpan lockWaitDuration)
         {
-#if DIAGNOSTICS && DEBUG
-            Console.WriteLine("{0}:AcquireWriteLock:IN:{1}: {2}", Thread.CurrentThread.ManagedThreadId, _id, lockWaitDuration);
-#endif
             if (_rwLock.TryEnterWriteLock(lockWaitDuration)) {
-#if DIAGNOSTICS && DEBUG
-                Console.WriteLine("{0}:AcquireWriteLock:OUT:{1}: {2}", Thread.CurrentThread.ManagedThreadId, _id, lockWaitDuration);
-#endif
-                return _wDisposable;
+                return new TrackedDisposable(ReleaseWriterLock);
             }
 
-#if DIAGNOSTICS && DEBUG
-            Console.WriteLine("{0}:AcquireWriteLock:ERR:{1}: {2}", Thread.CurrentThread.ManagedThreadId, _id, lockWaitDuration);
-#endif
             throw new TimeoutException("ReaderWriterLock timeout expired");
         }
 
@@ -150,28 +114,14 @@ namespace com.espertech.esper.compat.threading.locks
         /// <param name="timeout">The timeout.</param>
         public void AcquireReaderLock(long timeout)
         {
-#if DIAGNOSTICS && DEBUG
-            Console.WriteLine("{0}:AcquireReaderLock:IN:{1}: {2}", Thread.CurrentThread.ManagedThreadId, _id, timeout);
-#endif
-            try {
-                if (_useUpgradeableLocks) {
-                    if (_rwLock.TryEnterUpgradeableReadLock((int)timeout)) {
-                        return;
-                    }
-                }
-                else if (_rwLock.TryEnterReadLock((int)timeout)) {
+            if (_useUpgradeableLocks) {
+                if (_rwLock.TryEnterUpgradeableReadLock((int)timeout)) {
                     return;
                 }
             }
-            finally {
-#if DIAGNOSTICS && DEBUG
-                Console.WriteLine("{0}:AcquireReaderLock:OUT:{1}: {2}", Thread.CurrentThread.ManagedThreadId, _id, timeout);
-#endif
+            else if (_rwLock.TryEnterReadLock((int)timeout)) {
+                return;
             }
-
-#if DIAGNOSTICS && DEBUG
-            Console.WriteLine("{0}:AcquireReaderLock:ERR:{1}: {2}", Thread.CurrentThread.ManagedThreadId, _id, timeout);
-#endif
             throw new TimeoutException("ReaderWriterLock timeout expired");
         }
 
@@ -181,19 +131,9 @@ namespace com.espertech.esper.compat.threading.locks
         /// <param name="timeout">The timeout.</param>
         public void AcquireWriterLock(long timeout)
         {
-#if DIAGNOSTICS && DEBUG
-            Console.WriteLine("{0}:AcquireWriterLock:IN:{1}: {2}", Thread.CurrentThread.ManagedThreadId, _id, timeout);
-#endif
             if (_rwLock.TryEnterWriteLock((int) timeout)) {
-#if DIAGNOSTICS && DEBUG
-                Console.WriteLine("{0}:AcquireWriterLock:OUT:{1}: {2}", Thread.CurrentThread.ManagedThreadId, _id, timeout);
-#endif
                 return;
             }
-
-#if DIAGNOSTICS && DEBUG
-            Console.WriteLine("{0}:AcquireWriterLock:ERR:{1}: {2}", Thread.CurrentThread.ManagedThreadId, _id, timeout);
-#endif
             throw new TimeoutException("ReaderWriterLock timeout expired");
         }
 
@@ -202,18 +142,12 @@ namespace com.espertech.esper.compat.threading.locks
         /// </summary>
         public void ReleaseReaderLock()
         {
-#if DIAGNOSTICS && DEBUG
-            Console.WriteLine("{0}:ReleaseReaderLock:IN:{1}", Thread.CurrentThread.ManagedThreadId, _id);
-#endif
             if (_useUpgradeableLocks) {
                 _rwLock.ExitUpgradeableReadLock();
             }
             else {
                 _rwLock.ExitReadLock();
             }
-#if DIAGNOSTICS && DEBUG
-            Console.WriteLine("{0}:ReleaseReaderLock:OUT:{1}", Thread.CurrentThread.ManagedThreadId, _id);
-#endif
         }
 
         /// <summary>
@@ -221,13 +155,7 @@ namespace com.espertech.esper.compat.threading.locks
         /// </summary>
         public void ReleaseWriterLock()
         {
-#if DIAGNOSTICS && DEBUG
-            Console.WriteLine("{0}:ReleaseWriterLock:IN:{1}", Thread.CurrentThread.ManagedThreadId, _id);
-#endif
             _rwLock.ExitWriteLock();
-#if DIAGNOSTICS && DEBUG
-            Console.WriteLine("{0}:ReleaseWriterLock:OUT:{1}", Thread.CurrentThread.ManagedThreadId, _id);
-#endif
         }
     }
 }

--- a/src/NEsper.Compat/compat/threading/locks/StandardReaderWriterLock.cs
+++ b/src/NEsper.Compat/compat/threading/locks/StandardReaderWriterLock.cs
@@ -12,6 +12,7 @@ using System.Threading;
 
 namespace com.espertech.esper.compat.threading.locks
 {
+    [Obsolete("Use SlimReaderWriterLock instead. ReaderWriterLock (the underlying type) has known writer-starvation issues and worse performance than ReaderWriterLockSlim.")]
     public sealed class StandardReaderWriterLock
         : IReaderWriterLock,
             IReaderWriterLockCommon

--- a/src/NEsper.Compat/compat/threading/locks/TelemetryLock.cs
+++ b/src/NEsper.Compat/compat/threading/locks/TelemetryLock.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Threading;
 
 namespace com.espertech.esper.compat.threading.locks
 {
@@ -67,12 +68,10 @@ namespace com.espertech.esper.compat.threading.locks
             var disposableLock = _subLock.Acquire();
             var timeLockAcquired = PerformanceObserver.MicroTime;
             var disposableTrack = new TrackedDisposable(
-                delegate
-                    {
-                        disposableLock.Dispose();
-                        disposableLock = null;
-                        FinishTrackingPerformance(timeLockRequested, timeLockAcquired);
-                    });
+                delegate {
+                    Interlocked.Exchange(ref disposableLock, null)?.Dispose();
+                    FinishTrackingPerformance(timeLockRequested, timeLockAcquired);
+                });
 
             return disposableTrack;
         }
@@ -85,24 +84,7 @@ namespace com.espertech.esper.compat.threading.locks
             var disposableTrack = new TrackedDisposable(
                 delegate
                 {
-                    disposableLock.Dispose();
-                    disposableLock = null;
-                    FinishTrackingPerformance(timeLockRequested, timeLockAcquired);
-                });
-
-            return disposableTrack;
-        }
-
-        public IDisposable Acquire(bool releaseLock, long? msec = null)
-        {
-            var timeLockRequested = PerformanceObserver.MicroTime;
-            var disposableLock = _subLock.Acquire(releaseLock, msec: msec);
-            var timeLockAcquired = PerformanceObserver.MicroTime;
-            var disposableTrack = new TrackedDisposable(
-                delegate
-                {
-                    disposableLock.Dispose();
-                    disposableLock = null;
+                    Interlocked.Exchange(ref disposableLock, null)?.Dispose();
                     FinishTrackingPerformance(timeLockRequested, timeLockAcquired);
                 });
 
@@ -123,8 +105,7 @@ namespace com.espertech.esper.compat.threading.locks
             var disposableTrack = new TrackedDisposable(
                 delegate
                 {
-                    disposableLock.Dispose();
-                    disposableLock = null;
+                    Interlocked.Exchange(ref disposableLock, null)?.Dispose();
                     FinishTrackingPerformance(timeLockRequested, timeLockAcquired);
                 });
 

--- a/src/NEsper.Compat/compat/threading/locks/TelemetryReaderWriterLock.cs
+++ b/src/NEsper.Compat/compat/threading/locks/TelemetryReaderWriterLock.cs
@@ -38,10 +38,7 @@ namespace com.espertech.esper.compat.threading.locks
         /// <param name="e">The <see cref="TelemetryEventArgs"/> instance containing the event data.</param>
         protected void OnReadLockReleased(TelemetryEventArgs e)
         {
-            if (ReadLockReleased != null)
-            {
-                ReadLockReleased(this, e);
-            }
+            ReadLockReleased?.Invoke(this, e);
         }
 
         /// <summary>
@@ -50,10 +47,7 @@ namespace com.espertech.esper.compat.threading.locks
         /// <param name="e">The <see cref="TelemetryEventArgs"/> instance containing the event data.</param>
         protected void OnWriteLockReleased(TelemetryEventArgs e)
         {
-            if (WriteLockReleased != null)
-            {
-                WriteLockReleased(this, e);
-            }
+            WriteLockReleased?.Invoke(this, e);
         }
 
         /// <summary>
@@ -113,17 +107,13 @@ namespace com.espertech.esper.compat.threading.locks
             _id = Guid.NewGuid().ToString();
             _subLock = subLock;
 
-            do {
-                var telemetryLock = new TelemetryLock(_id, _subLock.ReadLock);
-                telemetryLock.LockReleased += (sender, e) => OnReadLockReleased(e);
-                ReadLock = telemetryLock;
-            } while (false);
+            var readTelemetry = new TelemetryLock(_id, _subLock.ReadLock);
+            readTelemetry.LockReleased += (sender, e) => OnReadLockReleased(e);
+            ReadLock = readTelemetry;
 
-            do {
-                var telemetryLock = new TelemetryLock(_id, _subLock.WriteLock);
-                telemetryLock.LockReleased += (sender, e) => OnWriteLockReleased(e);
-                WriteLock = telemetryLock;
-            } while (false);
+            var writeTelemetry = new TelemetryLock(_id, _subLock.WriteLock);
+            writeTelemetry.LockReleased += (sender, e) => OnWriteLockReleased(e);
+            WriteLock = writeTelemetry;
         }
     }
 }

--- a/src/NEsper.Compat/compat/threading/locks/VoidLock.cs
+++ b/src/NEsper.Compat/compat/threading/locks/VoidLock.cs
@@ -18,20 +18,6 @@ namespace com.espertech.esper.compat.threading.locks
         }
 
         /// <summary>
-        /// Acquire the lock; the lock is released when the disposable
-        /// object that was returned is disposed IF the releaseLock
-        /// flag is set.
-        /// </summary>
-        /// <param name="releaseLock"></param>
-        /// <param name="msec"></param>
-        /// <returns></returns>
-        public IDisposable Acquire(bool releaseLock, long? msec = null)
-        {
-            return _singleton;
-            //return new VoidDisposable();
-        }
-
-        /// <summary>
         /// Acquires the specified msec.
         /// </summary>
         /// <param name="msec">The msec.</param>

--- a/test-batches.json
+++ b/test-batches.json
@@ -13,6 +13,7 @@
       "filter": "TestClient",
       "enabled": true,
       "timeout": 300000,
+      "requiresDatabase": false,
       "description": "Client basic tests - quick validation"
     },
     {
@@ -20,6 +21,7 @@
       "filter": "TestContext",
       "enabled": true,
       "timeout": 600000,
+      "requiresDatabase": true,
       "description": "Context tests - moderate complexity"
     },
     {
@@ -27,6 +29,7 @@
       "filter": "TestEPLDatabase",
       "enabled": true,
       "timeout": 300000,
+      "requiresDatabase": true,
       "description": "Database integration tests"
     },
     {
@@ -34,6 +37,7 @@
       "filter": "TestEPLDataflow",
       "enabled": true,
       "timeout": 600000,
+      "requiresDatabase": false,
       "description": "Dataflow tests - some isolation issues"
     },
     {
@@ -41,6 +45,7 @@
       "filter": "TestEPLFromClauseMethod",
       "enabled": true,
       "timeout": 300000,
+      "requiresDatabase": false,
       "description": "FROM clause method tests"
     },
     {
@@ -48,6 +53,7 @@
       "filter": "TestEPLJoin",
       "enabled": true,
       "timeout": 600000,
+      "requiresDatabase": false,
       "description": "Join tests - complex queries"
     },
     {
@@ -55,6 +61,7 @@
       "filter": "TestEPLOther",
       "enabled": true,
       "timeout": 600000,
+      "requiresDatabase": false,
       "description": "Other EPL tests - large batch"
     },
     {
@@ -62,6 +69,7 @@
       "filter": "TestEPLSubselect",
       "enabled": true,
       "timeout": 600000,
+      "requiresDatabase": false,
       "description": "Subselect tests"
     },
     {
@@ -69,6 +77,7 @@
       "filter": "TestEvent",
       "enabled": true,
       "timeout": 600000,
+      "requiresDatabase": false,
       "description": "Event tests - includes 4 known XML XPath failures"
     },
     {
@@ -76,6 +85,7 @@
       "filter": "TestExpr",
       "enabled": true,
       "timeout": 600000,
+      "requiresDatabase": false,
       "description": "Expression tests - large batch"
     },
     {
@@ -83,6 +93,7 @@
       "filter": "TestInfra",
       "enabled": true,
       "timeout": 600000,
+      "requiresDatabase": false,
       "description": "Infrastructure tests - tables, named windows"
     },
     {
@@ -90,6 +101,7 @@
       "filter": "TestMultithreaded",
       "enabled": true,
       "timeout": 300000,
+      "requiresDatabase": true,
       "description": "Multithreaded tests - may have timing issues"
     },
     {
@@ -97,6 +109,7 @@
       "filter": "TestPattern",
       "enabled": true,
       "timeout": 600000,
+      "requiresDatabase": false,
       "description": "Pattern tests - includes 2 intermittent failures"
     },
     {
@@ -104,6 +117,7 @@
       "filter": "TestResultSet",
       "enabled": true,
       "timeout": 600000,
+      "requiresDatabase": false,
       "description": "Result set tests"
     },
     {
@@ -111,6 +125,7 @@
       "filter": "TestRowRecog",
       "enabled": true,
       "timeout": 600000,
+      "requiresDatabase": false,
       "description": "Row recognition tests - includes 1 intermittent failure"
     },
     {
@@ -118,6 +133,7 @@
       "filter": "TestView",
       "enabled": true,
       "timeout": 600000,
+      "requiresDatabase": false,
       "description": "View tests"
     }
   ],

--- a/tst/NEsper.Compat.Tests/compat/TrackedDisposableTests.cs
+++ b/tst/NEsper.Compat.Tests/compat/TrackedDisposableTests.cs
@@ -1,0 +1,117 @@
+// Copyright (C) 2006-2024 Esper Team. All rights reserved.
+// Subject to the terms of the GPL license (see license.txt).
+
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+namespace com.espertech.esper.compat
+{
+    /// <summary>
+    /// Tests for Task 1.1: TrackedDisposable double-dispose guard.
+    ///
+    /// The IDisposable contract requires that calling Dispose() more than once is safe.
+    /// Previously, TrackedDisposable invoked the action on every call. For locks, a second
+    /// Dispose() would attempt a second release — either throwing SynchronizationLockException
+    /// or silently corrupting state.
+    ///
+    /// FIX: Dispose() uses Interlocked.Exchange(ref _actionOnDispose, null)?.Invoke(), which
+    /// atomically swaps the field to null and invokes only if it was non-null. This ensures
+    /// the action runs exactly once and releases the closure reference after first dispose,
+    /// allowing the GC to collect whatever the action captured.
+    /// </summary>
+    [TestFixture]
+    public class TrackedDisposableTests
+    {
+        [Test]
+        public void Dispose_InvokesAction_OnFirstCall()
+        {
+            int callCount = 0;
+            var td = new TrackedDisposable(() => callCount++);
+
+            td.Dispose();
+
+            Assert.That(callCount, Is.EqualTo(1),
+                "Action must be invoked exactly once on first Dispose().");
+        }
+
+        [Test]
+        public void Dispose_DoesNotInvokeAction_OnSubsequentCalls()
+        {
+            int callCount = 0;
+            var td = new TrackedDisposable(() => callCount++);
+
+            td.Dispose();
+            td.Dispose();
+            td.Dispose();
+
+            Assert.That(callCount, Is.EqualTo(1),
+                "Action must not be invoked on subsequent Dispose() calls (double-dispose guard).");
+        }
+
+        [Test]
+        public void Dispose_NeverCalled_ActionIsNeverInvoked()
+        {
+            int callCount = 0;
+            // ReSharper disable once UnusedVariable
+            var td = new TrackedDisposable(() => callCount++);
+
+            // td goes out of scope without Dispose() — action must remain un-invoked.
+            Assert.That(callCount, Is.EqualTo(0),
+                "Action must not be invoked if Dispose() is never called.");
+        }
+
+        [Test]
+        public void Dispose_UsingBlock_InvokesActionExactlyOnce()
+        {
+            int callCount = 0;
+
+            using (new TrackedDisposable(() => callCount++))
+            {
+                // no-op inside the using block
+            }
+
+            Assert.That(callCount, Is.EqualTo(1),
+                "Action must be invoked exactly once when used with a 'using' statement.");
+        }
+
+        [Test]
+        public void Dispose_ConcurrentCalls_InvokesActionExactlyOnce()
+        {
+            // Verifies that Interlocked.Exchange makes the guard thread-safe:
+            // when many threads race to dispose the same instance, the action fires once.
+            const int threadCount = 32;
+            int callCount = 0;
+            var td = new TrackedDisposable(() => Interlocked.Increment(ref callCount));
+
+            var barrier = new Barrier(threadCount);
+            var tasks = new Task[threadCount];
+            for (int i = 0; i < threadCount; i++)
+            {
+                tasks[i] = Task.Run(() =>
+                {
+                    barrier.SignalAndWait(); // all threads start simultaneously
+                    td.Dispose();
+                });
+            }
+
+            Task.WaitAll(tasks);
+
+            Assert.That(callCount, Is.EqualTo(1),
+                "Action must be invoked exactly once even when Dispose() is called concurrently from many threads.");
+        }
+
+        [Test]
+        public void Dispose_NullAction_DoesNotThrow()
+        {
+            // Edge case: consumer passes null. Dispose() should not throw NRE.
+            var td = new TrackedDisposable(null);
+
+            Assert.DoesNotThrow(() => td.Dispose(),
+                "Dispose() with a null action must not throw.");
+            Assert.DoesNotThrow(() => td.Dispose(),
+                "Second Dispose() with a null action must also not throw.");
+        }
+    }
+}

--- a/tst/NEsper.Compat.Tests/compat/threading/locks/CommonLockTests.cs
+++ b/tst/NEsper.Compat.Tests/compat/threading/locks/CommonLockTests.cs
@@ -1,0 +1,243 @@
+// Copyright (C) 2006-2024 Esper Team. All rights reserved.
+// Subject to the terms of the GPL license (see license.txt).
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using com.espertech.esper.compat.threading.locks;
+
+namespace com.espertech.esper.compat.threading.locks
+{
+    [TestFixture]
+    public class CommonLockTests
+    {
+        private const int LockTimeoutMs = 5000;
+
+        // ── CommonReadLock (non-generic, via SlimReaderWriterLock) ────────────────────────
+
+        [Test]
+        public void CommonReadLock_Acquire_ReturnsNonNullDisposable()
+        {
+            var rwl = new SlimReaderWriterLock(LockTimeoutMs);
+            using var d = rwl.ReadLock.Acquire();
+            Assert.That(d, Is.Not.Null);
+        }
+
+        [Test]
+        public void CommonReadLock_AcquireWithTimeout_Succeeds()
+        {
+            var rwl = new SlimReaderWriterLock(LockTimeoutMs);
+            Assert.DoesNotThrow(() =>
+            {
+                using var d = rwl.ReadLock.Acquire(2000L);
+            });
+        }
+
+        [Test]
+        public void CommonReadLock_Release_ReleasesLock()
+        {
+            var rwl = new SlimReaderWriterLock(LockTimeoutMs);
+            rwl.ReadLock.Acquire();
+            Assert.DoesNotThrow(() => rwl.ReadLock.Release());
+            Assert.DoesNotThrow(() =>
+            {
+                using var w = rwl.WriteLock.Acquire();
+            });
+        }
+
+        [Test]
+        public void CommonReadLock_ReleaseAcquire_ReleasesAndReacquires()
+        {
+            var rwl = new SlimReaderWriterLock(LockTimeoutMs);
+            var writerAcquiredDuringRelease = new ManualResetEventSlim(false);
+
+            using (rwl.ReadLock.Acquire())
+            {
+                using (rwl.ReadLock.ReleaseAcquire())
+                {
+                    var task = Task.Run(() =>
+                    {
+                        using (rwl.WriteLock.Acquire())
+                        {
+                            writerAcquiredDuringRelease.Set();
+                        }
+                    });
+                    Assert.That(writerAcquiredDuringRelease.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                        "Writer should acquire during read ReleaseAcquire.");
+                    task.Wait(TimeSpan.FromSeconds(5));
+                }
+            }
+        }
+
+        // ── CommonWriteLock (non-generic, via SlimReaderWriterLock) ──────────────────────
+
+        [Test]
+        public void CommonWriteLock_Acquire_ReturnsNonNullDisposable()
+        {
+            var rwl = new SlimReaderWriterLock(LockTimeoutMs);
+            using var d = rwl.WriteLock.Acquire();
+            Assert.That(d, Is.Not.Null);
+        }
+
+        [Test]
+        public void CommonWriteLock_AcquireWithTimeout_Succeeds()
+        {
+            var rwl = new SlimReaderWriterLock(LockTimeoutMs);
+            Assert.DoesNotThrow(() =>
+            {
+                using var d = rwl.WriteLock.Acquire(2000L);
+            });
+        }
+
+        [Test]
+        public void CommonWriteLock_Release_ReleasesLock()
+        {
+            var rwl = new SlimReaderWriterLock(LockTimeoutMs);
+            rwl.WriteLock.Acquire();
+            Assert.DoesNotThrow(() => rwl.WriteLock.Release());
+            Assert.DoesNotThrow(() =>
+            {
+                using var r = rwl.ReadLock.Acquire();
+            });
+        }
+
+        [Test]
+        public void CommonWriteLock_ReleaseAcquire_ReleasesAndReacquires()
+        {
+            var rwl = new SlimReaderWriterLock(LockTimeoutMs);
+            var readerAcquiredDuringRelease = new ManualResetEventSlim(false);
+
+            using (rwl.WriteLock.Acquire())
+            {
+                using (rwl.WriteLock.ReleaseAcquire())
+                {
+                    var task = Task.Run(() =>
+                    {
+                        using (rwl.ReadLock.Acquire())
+                        {
+                            readerAcquiredDuringRelease.Set();
+                        }
+                    });
+                    Assert.That(readerAcquiredDuringRelease.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                        "Reader should acquire during write ReleaseAcquire.");
+                    task.Wait(TimeSpan.FromSeconds(5));
+                }
+            }
+        }
+
+        // ── CommonReadLock<T> (generic, via FifoReaderWriterLock) ────────────────────────
+
+        [Test]
+        public void CommonReadLockGeneric_Acquire_ReturnsNonNullDisposable()
+        {
+            var rwl = new FifoReaderWriterLock(LockTimeoutMs);
+            using var d = rwl.ReadLock.Acquire();
+            Assert.That(d, Is.Not.Null);
+        }
+
+        [Test]
+        public void CommonReadLockGeneric_AcquireWithTimeout_Succeeds()
+        {
+            var rwl = new FifoReaderWriterLock(LockTimeoutMs);
+            Assert.DoesNotThrow(() =>
+            {
+                using var d = rwl.ReadLock.Acquire(2000L);
+            });
+        }
+
+        [Test]
+        public void CommonReadLockGeneric_Release_ReleasesLock()
+        {
+            var rwl = new FifoReaderWriterLock(LockTimeoutMs);
+            rwl.ReadLock.Acquire();
+            Assert.DoesNotThrow(() => rwl.ReadLock.Release());
+            Assert.DoesNotThrow(() =>
+            {
+                using var w = rwl.WriteLock.Acquire();
+            });
+        }
+
+        [Test]
+        public void CommonReadLockGeneric_ReleaseAcquire_ReleasesAndReacquires()
+        {
+            var rwl = new FifoReaderWriterLock(LockTimeoutMs);
+            var writerAcquiredDuringRelease = new ManualResetEventSlim(false);
+
+            using (rwl.ReadLock.Acquire())
+            {
+                using (rwl.ReadLock.ReleaseAcquire())
+                {
+                    var task = Task.Run(() =>
+                    {
+                        using (rwl.WriteLock.Acquire())
+                        {
+                            writerAcquiredDuringRelease.Set();
+                        }
+                    });
+                    Assert.That(writerAcquiredDuringRelease.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                        "Writer should acquire during generic read ReleaseAcquire.");
+                    task.Wait(TimeSpan.FromSeconds(5));
+                }
+            }
+        }
+
+        // ── CommonWriteLock<T> (generic, via FifoReaderWriterLock) ───────────────────────
+
+        [Test]
+        public void CommonWriteLockGeneric_Acquire_ReturnsNonNullDisposable()
+        {
+            var rwl = new FifoReaderWriterLock(LockTimeoutMs);
+            using var d = rwl.WriteLock.Acquire();
+            Assert.That(d, Is.Not.Null);
+        }
+
+        [Test]
+        public void CommonWriteLockGeneric_AcquireWithTimeout_Succeeds()
+        {
+            var rwl = new FifoReaderWriterLock(LockTimeoutMs);
+            Assert.DoesNotThrow(() =>
+            {
+                using var d = rwl.WriteLock.Acquire(2000L);
+            });
+        }
+
+        [Test]
+        public void CommonWriteLockGeneric_Release_ReleasesLock()
+        {
+            var rwl = new FifoReaderWriterLock(LockTimeoutMs);
+            rwl.WriteLock.Acquire();
+            Assert.DoesNotThrow(() => rwl.WriteLock.Release());
+            Assert.DoesNotThrow(() =>
+            {
+                using var r = rwl.ReadLock.Acquire();
+            });
+        }
+
+        [Test]
+        public void CommonWriteLockGeneric_ReleaseAcquire_ReleasesAndReacquires()
+        {
+            var rwl = new FifoReaderWriterLock(LockTimeoutMs);
+            var readerAcquiredDuringRelease = new ManualResetEventSlim(false);
+
+            using (rwl.WriteLock.Acquire())
+            {
+                using (rwl.WriteLock.ReleaseAcquire())
+                {
+                    var task = Task.Run(() =>
+                    {
+                        using (rwl.ReadLock.Acquire())
+                        {
+                            readerAcquiredDuringRelease.Set();
+                        }
+                    });
+                    Assert.That(readerAcquiredDuringRelease.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                        "Reader should acquire during generic write ReleaseAcquire.");
+                    task.Wait(TimeSpan.FromSeconds(5));
+                }
+            }
+        }
+    }
+}

--- a/tst/NEsper.Compat.Tests/compat/threading/locks/DefaultLockManagerTests.cs
+++ b/tst/NEsper.Compat.Tests/compat/threading/locks/DefaultLockManagerTests.cs
@@ -1,0 +1,123 @@
+// Copyright (C) 2006-2024 Esper Team. All rights reserved.
+// Subject to the terms of the GPL license (see license.txt).
+
+using System;
+
+using NUnit.Framework;
+
+using com.espertech.esper.compat.threading.locks;
+
+namespace com.espertech.esper.compat.threading.locks
+{
+    [TestFixture]
+    public class DefaultLockManagerTests
+    {
+        // ── CreateLock(Type) ──────────────────────────────────────────────────────────────
+
+        [Test]
+        public void CreateLock_ByType_UsesDefaultFactory()
+        {
+            var manager = new DefaultLockManager(timeout => new MonitorLock(timeout));
+            var lck = manager.CreateLock(typeof(string));
+            Assert.That(lck, Is.Not.Null);
+            Assert.That(lck, Is.InstanceOf<MonitorLock>());
+        }
+
+        [Test]
+        public void CreateLock_ByType_WithRegisteredCategory_UsesRegisteredFactory()
+        {
+            var manager = new DefaultLockManager(timeout => new MonitorLock(timeout));
+            int factoryCalls = 0;
+            manager.RegisterCategoryLock(typeof(string), timeout =>
+            {
+                factoryCalls++;
+                return new MonitorSlimLock(timeout);
+            });
+
+            var lck = manager.CreateLock(typeof(string));
+            Assert.That(factoryCalls, Is.EqualTo(1));
+            Assert.That(lck, Is.InstanceOf<MonitorSlimLock>());
+        }
+
+        // ── CreateLock(Func<int, ILockable>) ─────────────────────────────────────────────
+
+        [Test]
+        public void CreateLock_WithFactory_UsesSuppliedFactory()
+        {
+            var manager = new DefaultLockManager(timeout => new MonitorLock(timeout));
+            int factoryCalls = 0;
+
+            var lck = manager.CreateLock(timeout =>
+            {
+                factoryCalls++;
+                return new MonitorSlimLock(timeout);
+            });
+
+            Assert.That(factoryCalls, Is.EqualTo(1));
+            Assert.That(lck, Is.InstanceOf<MonitorSlimLock>());
+        }
+
+        // ── RegisterCategoryLock(Type, ...) ───────────────────────────────────────────────
+
+        [Test]
+        public void RegisterCategoryLock_ByType_ResolvesOnCreateLockByType()
+        {
+            var manager = new DefaultLockManager(timeout => new MonitorLock(timeout));
+            manager.RegisterCategoryLock(typeof(int), timeout => new MonitorSlimLock(timeout));
+            var lck = manager.CreateLock(typeof(int));
+            Assert.That(lck, Is.InstanceOf<MonitorSlimLock>());
+        }
+
+        // ── Category prefix fallback algorithm ────────────────────────────────────────────
+
+        [Test]
+        public void CreateLock_CategoryPrefixFallback_MatchesRegisteredPrefix()
+        {
+            var manager = new DefaultLockManager(timeout => new MonitorLock(timeout));
+            manager.RegisterCategoryLock("com.example", timeout => new MonitorSlimLock(timeout));
+            var lck = manager.CreateLock("com.example.Service");
+            Assert.That(lck, Is.InstanceOf<MonitorSlimLock>(),
+                "Should fall back to the 'com.example' factory for a sub-category.");
+        }
+
+        [Test]
+        public void CreateLock_CategoryPrefixFallback_NoMatch_UsesDefaultFactory()
+        {
+            var manager = new DefaultLockManager(timeout => new MonitorLock(timeout));
+            manager.RegisterCategoryLock("other.ns", timeout => new MonitorSlimLock(timeout));
+            var lck = manager.CreateLock("com.example.Service");
+            Assert.That(lck, Is.InstanceOf<MonitorLock>(),
+                "Should use the default factory when no prefix matches.");
+        }
+
+        // ── IsTelemetryEnabled wrapping ───────────────────────────────────────────────────
+
+        [Test]
+        public void CreateDefaultLock_WithTelemetryEnabled_ReturnsTelemetryLock()
+        {
+            var manager = new DefaultLockManager(timeout => new MonitorLock(timeout));
+            manager.IsTelemetryEnabled = true;
+            var lck = manager.CreateDefaultLock();
+            Assert.That(lck, Is.InstanceOf<TelemetryLock>(),
+                "Should wrap the lock in a TelemetryLock when telemetry is enabled.");
+        }
+
+        [Test]
+        public void CreateLock_WithFactory_TelemetryEnabled_ReturnsTelemetryLock()
+        {
+            var manager = new DefaultLockManager(timeout => new MonitorLock(timeout));
+            manager.IsTelemetryEnabled = true;
+            var lck = manager.CreateLock(timeout => new MonitorSlimLock(timeout));
+            Assert.That(lck, Is.InstanceOf<TelemetryLock>());
+        }
+
+        [Test]
+        public void CreateLock_ByType_TelemetryEnabled_ReturnsTelemetryLock()
+        {
+            var manager = new DefaultLockManager(timeout => new MonitorLock(timeout));
+            manager.IsTelemetryEnabled = true;
+            var lck = manager.CreateLock(typeof(string));
+            Assert.That(lck, Is.InstanceOf<TelemetryLock>());
+        }
+    }
+}

--- a/tst/NEsper.Compat.Tests/compat/threading/locks/DefaultReaderWriterLockManagerTests.cs
+++ b/tst/NEsper.Compat.Tests/compat/threading/locks/DefaultReaderWriterLockManagerTests.cs
@@ -1,0 +1,254 @@
+// Copyright (C) 2006-2024 Esper Team. All rights reserved.
+// Subject to the terms of the GPL license (see license.txt).
+
+using System;
+
+using NUnit.Framework;
+
+using com.espertech.esper.compat.threading.locks;
+
+namespace com.espertech.esper.compat.threading.locks
+{
+    /// <summary>
+    /// Tests for Task 1.3a: DefaultReaderWriterLockManager.CreateDefaultLock throws
+    /// ApplicationException instead of InvalidOperationException when the factory is null.
+    ///
+    /// A missing factory is a programming error (misconfiguration), not a runtime fault.
+    /// The correct exception type is InvalidOperationException.
+    ///
+    /// STATUS: Tests currently FAIL because the method still throws ApplicationException.
+    ///         They will PASS once CreateDefaultLock(string) is changed to throw
+    ///         InvalidOperationException.
+    ///
+    /// For comparison, DefaultLockManager already throws InvalidOperationException (Task 1.3,
+    /// already fixed). Those tests are included here to document the expectation and prevent
+    /// regression.
+    /// </summary>
+    [TestFixture]
+    public class DefaultReaderWriterLockManagerTests
+    {
+        // ── DefaultReaderWriterLockManager (Task 1.3a — CURRENTLY FAILING) ──────────────
+
+        [Test]
+        public void CreateDefaultLock_WithNullFactory_ThrowsInvalidOperationException()
+        {
+            // FAILS NOW: throws ApplicationException
+            // PASSES AFTER FIX: change throw to InvalidOperationException
+            var manager = new DefaultReaderWriterLockManager(null);
+
+            Assert.Throws<InvalidOperationException>(
+                () => manager.CreateDefaultLock(),
+                "Missing factory is a configuration error; ApplicationException is the wrong type.");
+        }
+
+        [Test]
+        public void CreateDefaultLock_WithCategory_WithNullFactory_ThrowsInvalidOperationException()
+        {
+            // CreateDefaultLock(string) is the internal path; CreateDefaultLock() delegates to it.
+            // FAILS NOW: same ApplicationException throw site.
+            var manager = new DefaultReaderWriterLockManager(null);
+
+            // Any category that has no registered factory falls back to CreateDefaultLock(category).
+            Assert.Throws<InvalidOperationException>(
+                () => manager.CreateLock("some.unregistered.Category"),
+                "Category miss-fallback must raise InvalidOperationException, not ApplicationException.");
+        }
+
+        [Test]
+        public void CreateLock_WithNullCategory_WithNullFactory_ThrowsInvalidOperationException()
+        {
+            // Null category skips the lookup and goes straight to CreateDefaultLock.
+            var manager = new DefaultReaderWriterLockManager(null);
+
+            Assert.Throws<InvalidOperationException>(
+                () => manager.CreateLock((string)null),
+                "Null category must fall back to CreateDefaultLock and raise InvalidOperationException.");
+        }
+
+        // ── Positive cases: factory is set, no exception expected ────────────────────────
+
+        [Test]
+        public void CreateDefaultLock_WithFactory_Succeeds()
+        {
+            var manager = new DefaultReaderWriterLockManager(timeout => new SlimReaderWriterLock(timeout));
+            var rwLock = manager.CreateDefaultLock();
+            Assert.That(rwLock, Is.Not.Null);
+        }
+
+        [Test]
+        public void CreateLock_WithCategory_WithFactory_Succeeds()
+        {
+            var manager = new DefaultReaderWriterLockManager(timeout => new SlimReaderWriterLock(timeout));
+            var rwLock = manager.CreateLock("some.Category");
+            Assert.That(rwLock, Is.Not.Null);
+        }
+
+        [Test]
+        public void CreateLock_WithRegisteredCategoryFactory_UsesRegisteredFactory()
+        {
+            int factoryCalls = 0;
+            var manager = new DefaultReaderWriterLockManager(timeout => new SlimReaderWriterLock(timeout));
+            manager.RegisterCategoryLock("my.category", timeout =>
+            {
+                factoryCalls++;
+                return new SlimReaderWriterLock(timeout);
+            });
+
+            manager.CreateLock("my.category");
+            Assert.That(factoryCalls, Is.EqualTo(1), "Registered factory should have been called.");
+        }
+
+        // ── DefaultLockManager baseline (Task 1.3 — already fixed, regression guard) ───
+
+        [Test]
+        public void DefaultLockManager_CreateDefaultLock_WithNullFactory_ThrowsInvalidOperationException()
+        {
+            // Already throws InvalidOperationException — verify this doesn't regress.
+            var manager = new DefaultLockManager(null);
+            Assert.Throws<InvalidOperationException>(() => manager.CreateDefaultLock());
+        }
+
+        [Test]
+        public void DefaultLockManager_CreateLock_WithNullFactory_ThrowsInvalidOperationException()
+        {
+            var manager = new DefaultLockManager(null);
+            Assert.Throws<InvalidOperationException>(() => manager.CreateLock("some.Category"));
+        }
+
+        // ── Additional DefaultReaderWriterLockManager coverage (Phase 7b) ────────────────
+
+        [Test]
+        public void RegisterCategoryLock_GenericOverload_UsesTypeFullName()
+        {
+            int factoryCalls = 0;
+            var manager = new DefaultReaderWriterLockManager(timeout => new SlimReaderWriterLock(timeout));
+            manager.RegisterCategoryLock<SlimReaderWriterLock>(timeout =>
+            {
+                factoryCalls++;
+                return new FairReaderWriterLock(timeout);
+            });
+
+            manager.CreateLock(typeof(SlimReaderWriterLock));
+            Assert.That(factoryCalls, Is.EqualTo(1), "Generic RegisterCategoryLock<T> should register by typeof(T).FullName.");
+        }
+
+        [Test]
+        public void RegisterCategoryLock_TypeOverload_UsesTypeFullName()
+        {
+            int factoryCalls = 0;
+            var manager = new DefaultReaderWriterLockManager(timeout => new SlimReaderWriterLock(timeout));
+            manager.RegisterCategoryLock(typeof(FairReaderWriterLock), timeout =>
+            {
+                factoryCalls++;
+                return new SlimReaderWriterLock(timeout);
+            });
+
+            manager.CreateLock(typeof(FairReaderWriterLock));
+            Assert.That(factoryCalls, Is.EqualTo(1), "RegisterCategoryLock(Type, ...) should register by type.FullName.");
+        }
+
+        [Test]
+        public void CreateLock_ByType_NonGeneric_UsesDefaultFactory()
+        {
+            var manager = new DefaultReaderWriterLockManager(timeout => new SlimReaderWriterLock(timeout));
+            var lck = manager.CreateLock(typeof(SlimReaderWriterLock));
+            Assert.That(lck, Is.Not.Null);
+            Assert.That(lck, Is.InstanceOf<SlimReaderWriterLock>());
+        }
+
+        [Test]
+        public void CreateLock_ByType_GenericType_BacktickSuffixIsStripped()
+        {
+            var manager = new DefaultReaderWriterLockManager(timeout => new SlimReaderWriterLock(timeout));
+            int factoryCalls = 0;
+            // Register the stripped name (without `1 suffix)
+            string strippedName = typeof(System.Collections.Generic.List<int>).FullName;
+            int backtickIdx = strippedName.IndexOf('`');
+            if (backtickIdx != -1)
+            {
+                strippedName = strippedName.Substring(0, backtickIdx);
+            }
+            manager.RegisterCategoryLock(strippedName, timeout =>
+            {
+                factoryCalls++;
+                return new FairReaderWriterLock(timeout);
+            });
+
+            manager.CreateLock(typeof(System.Collections.Generic.List<int>));
+            Assert.That(factoryCalls, Is.EqualTo(1), "Generic type name backtick suffix should be stripped before category lookup.");
+        }
+
+        [Test]
+        public void CreateLock_WithFactory_UsesSuppliedFactory()
+        {
+            var manager = new DefaultReaderWriterLockManager(timeout => new SlimReaderWriterLock(timeout));
+            int factoryCalls = 0;
+            var lck = manager.CreateLock(timeout =>
+            {
+                factoryCalls++;
+                return new FairReaderWriterLock(timeout);
+            });
+
+            Assert.That(factoryCalls, Is.EqualTo(1));
+            Assert.That(lck, Is.InstanceOf<FairReaderWriterLock>());
+        }
+
+        [Test]
+        public void CreateLock_CategoryPrefixFallback_MatchesRegisteredPrefix()
+        {
+            var manager = new DefaultReaderWriterLockManager(timeout => new SlimReaderWriterLock(timeout));
+            manager.RegisterCategoryLock("com.example", timeout => new FairReaderWriterLock(timeout));
+            var lck = manager.CreateLock("com.example.Service");
+            Assert.That(lck, Is.InstanceOf<FairReaderWriterLock>(),
+                "Should fall back to the 'com.example' factory for a sub-category.");
+        }
+
+        [Test]
+        public void CreateLock_CategoryPrefixFallback_NoMatch_UsesDefaultFactory()
+        {
+            var manager = new DefaultReaderWriterLockManager(timeout => new SlimReaderWriterLock(timeout));
+            manager.RegisterCategoryLock("other.ns", timeout => new FairReaderWriterLock(timeout));
+            var lck = manager.CreateLock("com.example.Service");
+            Assert.That(lck, Is.InstanceOf<SlimReaderWriterLock>(),
+                "Should use the default factory when no prefix matches.");
+        }
+
+        [Test]
+        public void CreateDefaultLock_WithTelemetryEnabled_ReturnsTelemetryReaderWriterLock()
+        {
+            var manager = new DefaultReaderWriterLockManager(timeout => new SlimReaderWriterLock(timeout));
+            manager.IsTelemetryEnabled = true;
+            var lck = manager.CreateDefaultLock();
+            Assert.That(lck, Is.InstanceOf<TelemetryReaderWriterLock>(),
+                "Should wrap the lock in a TelemetryReaderWriterLock when telemetry is enabled.");
+        }
+
+        [Test]
+        public void CreateLock_WithFactory_TelemetryEnabled_ReturnsTelemetryReaderWriterLock()
+        {
+            var manager = new DefaultReaderWriterLockManager(timeout => new SlimReaderWriterLock(timeout));
+            manager.IsTelemetryEnabled = true;
+            var lck = manager.CreateLock(timeout => new FairReaderWriterLock(timeout));
+            Assert.That(lck, Is.InstanceOf<TelemetryReaderWriterLock>());
+        }
+
+        [Test]
+        public void CreateDefaultLock_WithTelemetryEnabled_EventsFire()
+        {
+            var manager = new DefaultReaderWriterLockManager(timeout => new SlimReaderWriterLock(timeout));
+            manager.IsTelemetryEnabled = true;
+            var lck = (TelemetryReaderWriterLock)manager.CreateDefaultLock();
+
+            bool readFired = false;
+            bool writeFired = false;
+            lck.ReadLockReleased += (s, e) => readFired = true;
+            lck.WriteLockReleased += (s, e) => writeFired = true;
+
+            using (lck.AcquireReadLock()) { }
+            using (lck.AcquireWriteLock()) { }
+
+            Assert.That(readFired, Is.True);
+            Assert.That(writeFired, Is.True);
+        }
+    }
+}

--- a/tst/NEsper.Compat.Tests/compat/threading/locks/FairReaderWriterLockTests.cs
+++ b/tst/NEsper.Compat.Tests/compat/threading/locks/FairReaderWriterLockTests.cs
@@ -1,0 +1,371 @@
+// Copyright (C) 2006-2024 Esper Team. All rights reserved.
+// Subject to the terms of the GPL license (see license.txt).
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using com.espertech.esper.compat.threading.locks;
+
+namespace com.espertech.esper.compat.threading.locks
+{
+    /// <summary>
+    /// Tests for Task 1.6: FairReaderWriterLock outer loop does not check the total timeout
+    /// after SmartWait returns.
+    ///
+    /// NATURE OF BUG (different from 1.5 — NOT an infinite spin):
+    ///   The outer loop calls WithMainLock(timeCur, timeEnd, action).  When the lock state
+    ///   doesn't allow entry (action returns false), WithMainLock returns normally.  The loop
+    ///   then calls SmartWait(++ii) and updates timeCur — but does not immediately check
+    ///   whether timeCur has passed timeEnd.  It instead calls WithMainLock again, which
+    ///   itself will throw TimeoutException once timeOut = timeEnd - timeCur &lt;= 0.
+    ///
+    ///   Effect: the timeout is honoured, but with a potential overshoot of one SmartWait
+    ///   call.  For higher iteration counts SmartWait can sleep up to ~10 ms extra per cycle.
+    ///
+    /// FIX: after updating timeCur, add an explicit check:
+    ///   if (timeCur >= timeEnd)
+    ///       throw new TimeoutException("FairReaderWriterLock timeout expired");
+    ///
+    /// STATUS:
+    ///   "Does time out" tests — PASS both before and after fix (lock does eventually time out).
+    ///   "Times out within tight window" test — documents expected precision; may show overshoot.
+    ///   All other correctness tests — PASS both before and after fix.
+    ///
+    /// The value of these tests: they form the regression baseline that the fix must not break,
+    /// and they catch any future regression that turns the minor overshoot into a true hang.
+    /// </summary>
+    [TestFixture]
+    public class FairReaderWriterLockTests
+    {
+        private const int LockTimeoutMs = 300;
+
+        // ── Task 1.6: outer timeout check ───────────────────────────────────────────────
+
+        [Test]
+        public void AcquireReaderLock_WhenWriterHeld_ThrowsTimeoutException()
+        {
+            // AcquireReaderLock does time out eventually (via WithMainLock's own check),
+            // but the explicit outer guard is missing — verify the timeout fires at all.
+            //
+            // PASSES NOW (lock does time out, just possibly with small overshoot).
+            // PASSES AFTER FIX (timeout fires at the explicit check, no overshoot).
+
+            var fair = new FairReaderWriterLock(LockTimeoutMs);
+            var writerAcquired = new ManualResetEventSlim(false);
+            var releaseWriter = new ManualResetEventSlim(false);
+
+            var writerTask = Task.Run(() =>
+            {
+                using var w = fair.AcquireWriteLock();
+                writerAcquired.Set();
+                releaseWriter.Wait(TimeSpan.FromSeconds(30));
+            });
+
+            Assert.That(writerAcquired.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "Writer failed to acquire lock during test setup.");
+
+            try
+            {
+                // CommonReadLock.Acquire() → AcquireReaderLock(timeout)
+                Assert.Throws<TimeoutException>(
+                    () => fair.ReadLock.Acquire(),
+                    "Reader must throw TimeoutException while writer holds the lock.");
+            }
+            finally
+            {
+                releaseWriter.Set();
+                writerTask.Wait(TimeSpan.FromSeconds(5));
+            }
+        }
+
+        [Test]
+        public void AcquireWriterLock_WhenReaderHeld_ThrowsTimeoutException()
+        {
+            var fair = new FairReaderWriterLock(LockTimeoutMs);
+            var readerAcquired = new ManualResetEventSlim(false);
+            var releaseReader = new ManualResetEventSlim(false);
+
+            var readerTask = Task.Run(() =>
+            {
+                using var r = fair.AcquireReadLock();
+                readerAcquired.Set();
+                releaseReader.Wait(TimeSpan.FromSeconds(30));
+            });
+
+            Assert.That(readerAcquired.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "Reader failed to acquire lock during test setup.");
+
+            try
+            {
+                Assert.Throws<TimeoutException>(
+                    () => fair.WriteLock.Acquire(),
+                    "Writer must throw TimeoutException while reader holds the lock.");
+            }
+            finally
+            {
+                releaseReader.Set();
+                readerTask.Wait(TimeSpan.FromSeconds(5));
+            }
+        }
+
+        [Test]
+        public void AcquireReaderLock_WhenWriterHeld_TimesOutWithinReasonableWindow()
+        {
+            // Measures wall-clock duration of a timed-out reader acquisition.
+            //
+            // Without fix: one extra SmartWait cycle may run after timeout — small overshoot.
+            // With fix: times out as soon as timeCur >= timeEnd, no extra wait.
+            //
+            // The bound is deliberately loose (4×) to avoid flakiness on slow CI.
+            // The lower bound (> 0.5×) guards against spurious early returns.
+
+            const double lowerBoundFactor = 0.5;
+            const double upperBoundFactor = 4.0;
+
+            var fair = new FairReaderWriterLock(LockTimeoutMs);
+            var writerAcquired = new ManualResetEventSlim(false);
+            var releaseWriter = new ManualResetEventSlim(false);
+
+            var writerTask = Task.Run(() =>
+            {
+                using var w = fair.AcquireWriteLock();
+                writerAcquired.Set();
+                releaseWriter.Wait(TimeSpan.FromSeconds(30));
+            });
+
+            Assert.That(writerAcquired.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+            var sw = Stopwatch.StartNew();
+            try
+            {
+                Assert.Throws<TimeoutException>(() => fair.ReadLock.Acquire());
+            }
+            finally
+            {
+                releaseWriter.Set();
+                writerTask.Wait(TimeSpan.FromSeconds(5));
+            }
+            sw.Stop();
+
+            long elapsedMs = sw.ElapsedMilliseconds;
+            Assert.That(elapsedMs, Is.GreaterThan((long)(LockTimeoutMs * lowerBoundFactor)),
+                $"Timed out too quickly ({elapsedMs} ms); expected at least {LockTimeoutMs * lowerBoundFactor} ms.");
+            Assert.That(elapsedMs, Is.LessThan((long)(LockTimeoutMs * upperBoundFactor)),
+                $"Timed out too slowly ({elapsedMs} ms); should fire within {LockTimeoutMs * upperBoundFactor} ms.");
+        }
+
+        [Test]
+        public void AcquireWriterLock_WhenReaderHeld_TimesOutWithinReasonableWindow()
+        {
+            const double lowerBoundFactor = 0.5;
+            const double upperBoundFactor = 4.0;
+
+            var fair = new FairReaderWriterLock(LockTimeoutMs);
+            var readerAcquired = new ManualResetEventSlim(false);
+            var releaseReader = new ManualResetEventSlim(false);
+
+            var readerTask = Task.Run(() =>
+            {
+                using var r = fair.AcquireReadLock();
+                readerAcquired.Set();
+                releaseReader.Wait(TimeSpan.FromSeconds(30));
+            });
+
+            Assert.That(readerAcquired.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+            var sw = Stopwatch.StartNew();
+            try
+            {
+                Assert.Throws<TimeoutException>(() => fair.WriteLock.Acquire());
+            }
+            finally
+            {
+                releaseReader.Set();
+                readerTask.Wait(TimeSpan.FromSeconds(5));
+            }
+            sw.Stop();
+
+            long elapsedMs = sw.ElapsedMilliseconds;
+            Assert.That(elapsedMs, Is.GreaterThan((long)(LockTimeoutMs * lowerBoundFactor)),
+                $"Timed out too quickly ({elapsedMs} ms).");
+            Assert.That(elapsedMs, Is.LessThan((long)(LockTimeoutMs * upperBoundFactor)),
+                $"Timed out too slowly ({elapsedMs} ms).");
+        }
+
+        // ── IsWriterLockHeld ─────────────────────────────────────────────────────────────
+
+        [Test]
+        public void IsWriterLockHeld_FalseInitially()
+        {
+            var fair = new FairReaderWriterLock(LockConstants.DefaultTimeout);
+            Assert.That(fair.IsWriterLockHeld, Is.False);
+        }
+
+        [Test]
+        public void IsWriterLockHeld_TrueWhileWriteLockHeld_FalseAfterRelease()
+        {
+            var fair = new FairReaderWriterLock(LockConstants.DefaultTimeout);
+
+            using (fair.AcquireWriteLock())
+            {
+                Assert.That(fair.IsWriterLockHeld, Is.True,
+                    "IsWriterLockHeld must be true while write lock is held by current thread.");
+            }
+
+            Assert.That(fair.IsWriterLockHeld, Is.False,
+                "IsWriterLockHeld must be false after write lock is released.");
+        }
+
+        [Test]
+        public void IsWriterLockHeld_FalseWhileReadLockHeld()
+        {
+            var fair = new FairReaderWriterLock(LockConstants.DefaultTimeout);
+
+            using (fair.AcquireReadLock())
+            {
+                Assert.That(fair.IsWriterLockHeld, Is.False,
+                    "IsWriterLockHeld must be false when only a read lock is held.");
+            }
+        }
+
+        [Test]
+        public void IsWriterLockHeld_FalseOnNonOwnerThread_WhileOwnerHoldsWriteLock()
+        {
+            var fair = new FairReaderWriterLock(LockConstants.DefaultTimeout);
+            var writerAcquired = new ManualResetEventSlim(false);
+            var releaseWriter = new ManualResetEventSlim(false);
+            bool? observedOnOtherThread = null;
+
+            var writerTask = Task.Run(() =>
+            {
+                using var w = fair.AcquireWriteLock();
+                writerAcquired.Set();
+                releaseWriter.Wait(TimeSpan.FromSeconds(10));
+            });
+
+            Assert.That(writerAcquired.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+            // Check IsWriterLockHeld from a different thread — must be false (it's owner-thread-specific).
+            var observerTask = Task.Run(() => observedOnOtherThread = fair.IsWriterLockHeld);
+            observerTask.Wait(TimeSpan.FromSeconds(5));
+
+            releaseWriter.Set();
+            writerTask.Wait(TimeSpan.FromSeconds(5));
+
+            Assert.That(observedOnOtherThread, Is.False,
+                "IsWriterLockHeld must return false on a thread that does not own the write lock.");
+        }
+
+        // ── Basic correctness tests (PASS both before and after fix) ─────────────────────
+
+        [Test]
+        public void AcquireReadLock_WithNoContention_Succeeds()
+        {
+            var fair = new FairReaderWriterLock(LockConstants.DefaultTimeout);
+            Assert.DoesNotThrow(() =>
+            {
+                using var r = fair.AcquireReadLock();
+            });
+        }
+
+        [Test]
+        public void AcquireWriteLock_WithNoContention_Succeeds()
+        {
+            var fair = new FairReaderWriterLock(LockConstants.DefaultTimeout);
+            Assert.DoesNotThrow(() =>
+            {
+                using var w = fair.AcquireWriteLock();
+            });
+        }
+
+        [Test]
+        public void MultipleReaders_CanHoldLockConcurrently()
+        {
+            var fair = new FairReaderWriterLock(LockConstants.DefaultTimeout);
+            var reader1Ready = new ManualResetEventSlim(false);
+            var reader2Ready = new ManualResetEventSlim(false);
+            var readersCanRelease = new ManualResetEventSlim(false);
+            var errors = new System.Collections.Concurrent.ConcurrentBag<Exception>();
+
+            void Reader(ManualResetEventSlim ready)
+            {
+                try
+                {
+                    using var r = fair.AcquireReadLock();
+                    ready.Set();
+                    readersCanRelease.Wait(TimeSpan.FromSeconds(10));
+                }
+                catch (Exception ex) { errors.Add(ex); }
+            }
+
+            var t1 = Task.Run(() => Reader(reader1Ready));
+            var t2 = Task.Run(() => Reader(reader2Ready));
+
+            Assert.That(reader1Ready.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "Reader 1 should acquire lock.");
+            Assert.That(reader2Ready.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "Reader 2 should acquire lock concurrently with reader 1.");
+
+            readersCanRelease.Set();
+            Task.WaitAll(new[] { t1, t2 }, TimeSpan.FromSeconds(5));
+
+            Assert.That(errors, Is.Empty, "Concurrent readers must not throw.");
+        }
+
+        [Test]
+        public void WriterBlocksReader_AndReaderRelease_AllowsWriter()
+        {
+            var fair = new FairReaderWriterLock(LockConstants.DefaultTimeout);
+            var readerAcquired = new ManualResetEventSlim(false);
+            var releaseReader = new ManualResetEventSlim(false);
+            var writerAcquired = new ManualResetEventSlim(false);
+
+            var readerTask = Task.Run(() =>
+            {
+                using var r = fair.AcquireReadLock();
+                readerAcquired.Set();
+                releaseReader.Wait(TimeSpan.FromSeconds(10));
+            });
+
+            Assert.That(readerAcquired.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+            var writerTask = Task.Run(() =>
+            {
+                using var w = fair.AcquireWriteLock();
+                writerAcquired.Set();
+            });
+
+            // Writer must not acquire while reader holds.
+            bool writerAcquiredEarly = writerAcquired.Wait(TimeSpan.FromMilliseconds(100));
+            Assert.That(writerAcquiredEarly, Is.False, "Writer must not acquire while reader holds.");
+
+            // Release reader.
+            releaseReader.Set();
+            Assert.That(writerAcquired.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "Writer must acquire once reader releases.");
+
+            readerTask.Wait(TimeSpan.FromSeconds(5));
+            writerTask.Wait(TimeSpan.FromSeconds(5));
+        }
+
+        [Test]
+        public void AcquireReadLock_AfterWriterReleases_Succeeds()
+        {
+            var fair = new FairReaderWriterLock(LockConstants.DefaultTimeout);
+
+            using (fair.AcquireWriteLock())
+            {
+                // writer briefly held
+            }
+
+            Assert.DoesNotThrow(() =>
+            {
+                using var r = fair.AcquireReadLock();
+            });
+        }
+    }
+}

--- a/tst/NEsper.Compat.Tests/compat/threading/locks/FifoReaderWriterLockTests.cs
+++ b/tst/NEsper.Compat.Tests/compat/threading/locks/FifoReaderWriterLockTests.cs
@@ -1,0 +1,265 @@
+// Copyright (C) 2006-2024 Esper Team. All rights reserved.
+// Subject to the terms of the GPL license (see license.txt).
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using com.espertech.esper.compat.threading.locks;
+
+namespace com.espertech.esper.compat.threading.locks
+{
+    /// <summary>
+    /// Tests for FifoReaderWriterLock.AcquireReaderLock(long) and AcquireWriterLock(long).
+    ///
+    /// Both methods compute a deadline (timeEnd) and pass it to
+    /// SlimLock.SmartWait(iter, timeEnd), which returns false when the deadline
+    /// expires, causing a TimeoutException to be thrown from the spin loop.
+    ///
+    /// Timeout tests  — verify that a timed-out acquisition faults with TimeoutException
+    ///                   within the expected window.
+    /// Correctness tests — verify basic lock/unlock and mutual-exclusion semantics.
+    /// </summary>
+    [TestFixture]
+    public class FifoReaderWriterLockTests
+    {
+        // The timeout passed to the lock under test.
+        private const int LockTimeoutMs = 200;
+
+        // How long we wait for the task before concluding it's stuck.
+        // 10× is generous enough for slow CI while staying far below "infinite".
+        private const int OuterWaitMs = LockTimeoutMs * 10;
+
+        // ── Timeout tests ───────────────────────────────────────────────────────────────
+
+        [Test]
+        public void AcquireReaderLock_WhenWriterHeld_TimesOutWithinExpectedWindow()
+        {
+            // Verifies that AcquireReaderLock honours the timeout argument by passing
+            // timeEnd to SlimLock.SmartWait(iter, timeEnd), which returns false when the
+            // deadline is exceeded, causing a TimeoutException to be thrown.
+
+            var fifo = new FifoReaderWriterLock(LockConstants.DefaultTimeout);
+            var writerAcquired = new ManualResetEventSlim(false);
+            var releaseWriter = new ManualResetEventSlim(false);
+
+            var writerTask = Task.Run(() =>
+            {
+                using var w = fifo.AcquireWriteLock();
+                writerAcquired.Set();
+                releaseWriter.Wait(TimeSpan.FromSeconds(30));
+            });
+
+            Assert.That(writerAcquired.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "Writer failed to acquire lock during test setup.");
+
+            // ReadLock.Acquire(ms) → CommonReadLock<Node>.Acquire(long) → AcquireReaderLock(long)
+            var readerTask = Task.Run(() => fifo.ReadLock.Acquire(LockTimeoutMs));
+            // Use WaitAny so a faulted task returns the index rather than throwing AggregateException.
+            bool completed = Task.WaitAny(new Task[] { readerTask }, TimeSpan.FromMilliseconds(OuterWaitMs)) != -1;
+
+            // Always release the writer so background tasks can drain.
+            releaseWriter.Set();
+            writerTask.Wait(TimeSpan.FromSeconds(5));
+
+            Assert.That(completed, Is.True,
+                $"Reader acquisition did not complete within {OuterWaitMs} ms — it spun indefinitely. " +
+                "timeEnd is computed in AcquireReaderLock but SmartWait(iter) is called " +
+                "instead of SmartWait(iter, timeEnd) (Task 1.5).");
+
+            Assert.That(readerTask.IsFaulted, Is.True,
+                "Timed-out acquisition must fault the task.");
+            Assert.That(readerTask.Exception!.InnerException, Is.InstanceOf<TimeoutException>(),
+                "The faulting exception must be TimeoutException.");
+        }
+
+        [Test]
+        public void AcquireWriterLock_WhenReaderHeld_TimesOutWithinExpectedWindow()
+        {
+            // Verifies that AcquireWriterLock honours the timeout argument by passing
+            // timeEnd to SlimLock.SmartWait(iter, timeEnd), which returns false when the
+            // deadline is exceeded, causing a TimeoutException to be thrown.
+
+            var fifo = new FifoReaderWriterLock(LockConstants.DefaultTimeout);
+            var readerAcquired = new ManualResetEventSlim(false);
+            var releaseReader = new ManualResetEventSlim(false);
+
+            var readerTask = Task.Run(() =>
+            {
+                using var r = fifo.AcquireReadLock();
+                readerAcquired.Set();
+                releaseReader.Wait(TimeSpan.FromSeconds(30));
+            });
+
+            Assert.That(readerAcquired.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "Reader failed to acquire lock during test setup.");
+
+            // WriteLock.Acquire(ms) → CommonWriteLock<Node>.Acquire(long) → AcquireWriterLock(long)
+            var contestedWriterTask = Task.Run(() => fifo.WriteLock.Acquire(LockTimeoutMs));
+            // Use WaitAny so a faulted task returns the index rather than throwing AggregateException.
+            bool completed = Task.WaitAny(new Task[] { contestedWriterTask }, TimeSpan.FromMilliseconds(OuterWaitMs)) != -1;
+
+            releaseReader.Set();
+            readerTask.Wait(TimeSpan.FromSeconds(5));
+
+            Assert.That(completed, Is.True,
+                $"Writer acquisition did not complete within {OuterWaitMs} ms — it spun indefinitely. " +
+                "timeEnd is computed in AcquireWriterLock but SmartWait(iter) is called " +
+                "instead of SmartWait(iter, timeEnd) (Task 1.5).");
+
+            Assert.That(contestedWriterTask.IsFaulted, Is.True,
+                "Timed-out acquisition must fault the task.");
+            Assert.That(contestedWriterTask.Exception!.InnerException, Is.InstanceOf<TimeoutException>(),
+                "The faulting exception must be TimeoutException.");
+        }
+
+        [Test]
+        public void AcquireReaderLock_WhenWriterHeld_ThenWriterReleases_ReaderAcquires()
+        {
+            // Paired with the timeout test: once the writer releases, the reader must
+            // proceed normally.  This verifies the spin loop logic is otherwise correct.
+
+            var fifo = new FifoReaderWriterLock(LockConstants.DefaultTimeout);
+            var writerAcquired = new ManualResetEventSlim(false);
+            var releaseWriter = new ManualResetEventSlim(false);
+            var readerAcquired = new ManualResetEventSlim(false);
+
+            var writerTask = Task.Run(() =>
+            {
+                using var w = fifo.AcquireWriteLock();
+                writerAcquired.Set();
+                releaseWriter.Wait(TimeSpan.FromSeconds(10));
+            });
+
+            Assert.That(writerAcquired.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "Writer failed to acquire lock during test setup.");
+
+            // Reader waits for writer — uses default (long) timeout so it doesn't time out.
+            var readerTask = Task.Run(() =>
+            {
+                using var r = fifo.AcquireReadLock();
+                readerAcquired.Set();
+            });
+
+            // Let reader spin for a moment, then release writer.
+            Thread.Sleep(50);
+            releaseWriter.Set();
+
+            Assert.That(readerAcquired.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "Reader should acquire once writer releases.");
+
+            writerTask.Wait(TimeSpan.FromSeconds(5));
+            readerTask.Wait(TimeSpan.FromSeconds(5));
+        }
+
+        // ── Basic correctness tests (PASS both before and after fix) ─────────────────────
+
+        [Test]
+        public void AcquireReadLock_WithNoContention_Succeeds()
+        {
+            var fifo = new FifoReaderWriterLock(LockConstants.DefaultTimeout);
+            Assert.DoesNotThrow(() =>
+            {
+                using var r = fifo.AcquireReadLock();
+            });
+        }
+
+        [Test]
+        public void AcquireWriteLock_WithNoContention_Succeeds()
+        {
+            var fifo = new FifoReaderWriterLock(LockConstants.DefaultTimeout);
+            Assert.DoesNotThrow(() =>
+            {
+                using var w = fifo.AcquireWriteLock();
+            });
+        }
+
+        [Test]
+        public void AcquireReadLock_AfterWriterReleases_Succeeds()
+        {
+            var fifo = new FifoReaderWriterLock(LockConstants.DefaultTimeout);
+
+            using (fifo.AcquireWriteLock())
+            {
+                // writer held
+            }
+
+            Assert.DoesNotThrow(() =>
+            {
+                using var r = fifo.AcquireReadLock();
+            });
+        }
+
+        [Test]
+        public void AcquireWriteLock_AfterReaderReleases_Succeeds()
+        {
+            var fifo = new FifoReaderWriterLock(LockConstants.DefaultTimeout);
+
+            using (fifo.AcquireReadLock())
+            {
+                // reader held
+            }
+
+            Assert.DoesNotThrow(() =>
+            {
+                using var w = fifo.AcquireWriteLock();
+            });
+        }
+
+        [Test]
+        public void IsWriterLockHeld_ReflectsActualState()
+        {
+            var fifo = new FifoReaderWriterLock(LockConstants.DefaultTimeout);
+
+            Assert.That(fifo.IsWriterLockHeld, Is.False, "No lock held initially.");
+
+            // IsWriterLockHeld checks _rnode.Flags == Exclusive on the calling thread.
+            // Since the write lock is acquired on this thread, it should return true.
+            using (fifo.AcquireWriteLock())
+            {
+                Assert.That(fifo.IsWriterLockHeld, Is.True, "Write lock held.");
+            }
+
+            Assert.That(fifo.IsWriterLockHeld, Is.False, "Write lock released.");
+        }
+
+        [Test]
+        public void WriterBlocksSubsequentWriter_UntilFirstReleases()
+        {
+            // FIFO ordering: second writer queues behind first; does not acquire concurrently.
+            var fifo = new FifoReaderWriterLock(LockConstants.DefaultTimeout);
+            var writer1Acquired = new ManualResetEventSlim(false);
+            var releaseWriter1 = new ManualResetEventSlim(false);
+            var writer2Acquired = new ManualResetEventSlim(false);
+
+            var w1Task = Task.Run(() =>
+            {
+                using var w = fifo.AcquireWriteLock();
+                writer1Acquired.Set();
+                releaseWriter1.Wait(TimeSpan.FromSeconds(10));
+            });
+
+            Assert.That(writer1Acquired.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+            var w2Task = Task.Run(() =>
+            {
+                using var w = fifo.AcquireWriteLock();
+                writer2Acquired.Set();
+            });
+
+            // Writer 2 must NOT acquire while writer 1 is held.
+            bool w2AcquiredEarly = writer2Acquired.Wait(TimeSpan.FromMilliseconds(150));
+            Assert.That(w2AcquiredEarly, Is.False, "Writer 2 should not acquire while writer 1 holds.");
+
+            // Release writer 1 — writer 2 should proceed.
+            releaseWriter1.Set();
+            Assert.That(writer2Acquired.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "Writer 2 should acquire after writer 1 releases.");
+
+            w1Task.Wait(TimeSpan.FromSeconds(5));
+            w2Task.Wait(TimeSpan.FromSeconds(5));
+        }
+    }
+}

--- a/tst/NEsper.Compat.Tests/compat/threading/locks/LockableExtensionsTests.cs
+++ b/tst/NEsper.Compat.Tests/compat/threading/locks/LockableExtensionsTests.cs
@@ -1,0 +1,98 @@
+// Copyright (C) 2006-2024 Esper Team. All rights reserved.
+// Subject to the terms of the GPL license (see license.txt).
+
+using System;
+
+using NUnit.Framework;
+
+using com.espertech.esper.compat.threading.locks;
+
+namespace com.espertech.esper.compat.threading.locks
+{
+    [TestFixture]
+    public class LockableExtensionsTests
+    {
+        // ── LockableExtensions ────────────────────────────────────────────────────────────
+
+        [Test]
+        public void Call_WithVoidLock_ExecutesActionExactlyOnce()
+        {
+            var vl = new VoidLock();
+            int callCount = 0;
+            vl.Call(() => callCount++);
+            Assert.That(callCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Call_WithMonitorLock_ExecutesActionExactlyOnce()
+        {
+            var ml = new MonitorLock();
+            int callCount = 0;
+            ml.Call(() => callCount++);
+            Assert.That(callCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void CallFunc_WithVoidLock_ReturnsExpectedValue()
+        {
+            var vl = new VoidLock();
+            int result = vl.Call(() => 42);
+            Assert.That(result, Is.EqualTo(42));
+        }
+
+        [Test]
+        public void CallFunc_WithMonitorLock_ReturnsExpectedValue()
+        {
+            var ml = new MonitorLock();
+            string result = ml.Call(() => "hello");
+            Assert.That(result, Is.EqualTo("hello"));
+        }
+
+        [Test]
+        public void Call_LockIsReleasedAfterAction()
+        {
+            var ml = new MonitorLock(500);
+            ml.Call(() => { });
+            Assert.DoesNotThrow(() => ml.Call(() => { }));
+        }
+
+        [Test]
+        public void CallFunc_LockIsReleasedAfterFunction()
+        {
+            var ml = new MonitorLock(500);
+            ml.Call(() => 1);
+            Assert.DoesNotThrow(() => ml.Call(() => 2));
+        }
+
+        // ── LockException ─────────────────────────────────────────────────────────────────
+
+        [Test]
+        public void LockException_DefaultConstructor_CreatesInstance()
+        {
+            var ex = new LockException();
+            Assert.That(ex, Is.Not.Null);
+        }
+
+        [Test]
+        public void LockException_MessageConstructor_PreservesMessage()
+        {
+            var ex = new LockException("test message");
+            Assert.That(ex.Message, Is.EqualTo("test message"));
+        }
+
+        [Test]
+        public void LockException_InnerExceptionConstructor_PreservesBoth()
+        {
+            var inner = new Exception("inner");
+            var ex = new LockException("outer", inner);
+            Assert.That(ex.Message, Is.EqualTo("outer"));
+            Assert.That(ex.InnerException, Is.SameAs(inner));
+        }
+
+        [Test]
+        public void LockException_CanBeThrownAndCaught()
+        {
+            Assert.Throws<LockException>(() => throw new LockException("thrown"));
+        }
+    }
+}

--- a/tst/NEsper.Compat.Tests/compat/threading/locks/MonitorLockTests.cs
+++ b/tst/NEsper.Compat.Tests/compat/threading/locks/MonitorLockTests.cs
@@ -1,0 +1,410 @@
+// Copyright (C) 2006-2024 Esper Team. All rights reserved.
+// Subject to the terms of the GPL license (see license.txt).
+
+#pragma warning disable CS0618
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using com.espertech.esper.compat.threading.locks;
+
+namespace com.espertech.esper.compat.threading.locks
+{
+    [TestFixture]
+    public class MonitorLockTests
+    {
+        private const int SmallTimeoutMs = 150;
+
+        // ── MonitorLock ───────────────────────────────────────────────────────────────────
+
+        [Test]
+        public void MonitorLock_BasicAcquireRelease_DoesNotThrow()
+        {
+            var ml = new MonitorLock();
+            Assert.DoesNotThrow(() =>
+            {
+                using var d = ml.Acquire();
+            });
+        }
+
+        [Test]
+        public void MonitorLock_AcquireWithTimeout_Succeeds()
+        {
+            var ml = new MonitorLock();
+            Assert.DoesNotThrow(() =>
+            {
+                using var d = ml.Acquire(1000L);
+            });
+        }
+
+        [Test]
+        public void MonitorLock_LockTimeout_ReflectsConstructorValue()
+        {
+            var ml = new MonitorLock(12345);
+            Assert.That(ml.LockTimeout, Is.EqualTo(12345));
+        }
+
+        [Test]
+        public void MonitorLock_LockDepth_IsOneWhileHeld_ZeroAfterRelease()
+        {
+            var ml = new MonitorLock();
+            using (ml.Acquire())
+            {
+                Assert.That(ml.LockDepth, Is.EqualTo(1));
+            }
+            Assert.That(ml.LockDepth, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void MonitorLock_IsHeldByCurrentThread_TrueInsideFalseOutside()
+        {
+            var ml = new MonitorLock();
+            Assert.That(ml.IsHeldByCurrentThread, Is.False);
+            using (ml.Acquire())
+            {
+                Assert.That(ml.IsHeldByCurrentThread, Is.True);
+            }
+            Assert.That(ml.IsHeldByCurrentThread, Is.False);
+        }
+
+        [Test]
+        public void MonitorLock_Reentrant_SameThread_DoesNotDeadlock()
+        {
+            var ml = new MonitorLock();
+            using (ml.Acquire())
+            {
+                Assert.That(ml.LockDepth, Is.EqualTo(1));
+                using (ml.Acquire())
+                {
+                    Assert.That(ml.LockDepth, Is.EqualTo(2));
+                }
+                Assert.That(ml.LockDepth, Is.EqualTo(1));
+            }
+            Assert.That(ml.LockDepth, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void MonitorLock_Release_DoesNotThrow()
+        {
+            var ml = new MonitorLock();
+            using (ml.Acquire())
+            {
+                Assert.DoesNotThrow(() => ml.Release());
+            }
+        }
+
+        [Test]
+        public void MonitorLock_ReleaseAcquire_TemporarilyReleasesLock()
+        {
+            var ml = new MonitorLock();
+            var otherThreadAcquired = new ManualResetEventSlim(false);
+
+            using (ml.Acquire())
+            {
+                using (ml.ReleaseAcquire())
+                {
+                    var task = Task.Run(() =>
+                    {
+                        using (ml.Acquire())
+                        {
+                            otherThreadAcquired.Set();
+                        }
+                    });
+                    Assert.That(otherThreadAcquired.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                        "Other thread should acquire the lock during ReleaseAcquire.");
+                    task.Wait(TimeSpan.FromSeconds(5));
+                }
+                Assert.That(ml.IsHeldByCurrentThread, Is.True,
+                    "Lock should be re-acquired after ReleaseAcquire disposable is disposed.");
+            }
+        }
+
+        [Test]
+        public void MonitorLock_TimeoutUnderContention_ThrowsTimeoutException()
+        {
+            var ml = new MonitorLock(SmallTimeoutMs);
+            var holderReady = new ManualResetEventSlim(false);
+            var releaseHolder = new ManualResetEventSlim(false);
+
+            var holder = Task.Run(() =>
+            {
+                using (ml.Acquire())
+                {
+                    holderReady.Set();
+                    releaseHolder.Wait(TimeSpan.FromSeconds(10));
+                }
+            });
+
+            Assert.That(holderReady.Wait(TimeSpan.FromSeconds(5)), Is.True);
+            try
+            {
+                Assert.Throws<TimeoutException>(() => ml.Acquire());
+            }
+            finally
+            {
+                releaseHolder.Set();
+                holder.Wait(TimeSpan.FromSeconds(5));
+            }
+        }
+
+        // ── MonitorSlimLock ───────────────────────────────────────────────────────────────
+
+        [Test]
+        public void MonitorSlimLock_BasicAcquireRelease_DoesNotThrow()
+        {
+            var ml = new MonitorSlimLock();
+            Assert.DoesNotThrow(() =>
+            {
+                using var d = ml.Acquire();
+            });
+        }
+
+        [Test]
+        public void MonitorSlimLock_AcquireWithTimeout_Succeeds()
+        {
+            var ml = new MonitorSlimLock();
+            Assert.DoesNotThrow(() =>
+            {
+                using var d = ml.Acquire(1000L);
+            });
+        }
+
+        [Test]
+        public void MonitorSlimLock_LockTimeout_ReflectsConstructorValue()
+        {
+            var ml = new MonitorSlimLock(54321);
+            Assert.That(ml.LockTimeout, Is.EqualTo(54321));
+        }
+
+        [Test]
+        public void MonitorSlimLock_LockDepth_IsOneWhileHeld_ZeroAfterRelease()
+        {
+            var ml = new MonitorSlimLock();
+            using (ml.Acquire())
+            {
+                Assert.That(ml.LockDepth, Is.EqualTo(1));
+            }
+            Assert.That(ml.LockDepth, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void MonitorSlimLock_IsHeldByCurrentThread_TrueInsideFalseOutside()
+        {
+            var ml = new MonitorSlimLock();
+            Assert.That(ml.IsHeldByCurrentThread, Is.False);
+            using (ml.Acquire())
+            {
+                Assert.That(ml.IsHeldByCurrentThread, Is.True);
+            }
+            Assert.That(ml.IsHeldByCurrentThread, Is.False);
+        }
+
+        [Test]
+        public void MonitorSlimLock_Reentrant_SameThread_DoesNotDeadlock()
+        {
+            var ml = new MonitorSlimLock();
+            using (ml.Acquire())
+            {
+                Assert.That(ml.LockDepth, Is.EqualTo(1));
+                using (ml.Acquire())
+                {
+                    Assert.That(ml.LockDepth, Is.EqualTo(2));
+                }
+                Assert.That(ml.LockDepth, Is.EqualTo(1));
+            }
+            Assert.That(ml.LockDepth, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void MonitorSlimLock_Release_DoesNotThrow()
+        {
+            var ml = new MonitorSlimLock();
+            using (ml.Acquire())
+            {
+                Assert.DoesNotThrow(() => ml.Release());
+            }
+        }
+
+        [Test]
+        public void MonitorSlimLock_ReleaseAcquire_TemporarilyReleasesLock()
+        {
+            var ml = new MonitorSlimLock();
+            var otherThreadAcquired = new ManualResetEventSlim(false);
+
+            using (ml.Acquire())
+            {
+                using (ml.ReleaseAcquire())
+                {
+                    var task = Task.Run(() =>
+                    {
+                        using (ml.Acquire())
+                        {
+                            otherThreadAcquired.Set();
+                        }
+                    });
+                    Assert.That(otherThreadAcquired.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                        "Other thread should acquire the lock during ReleaseAcquire.");
+                    task.Wait(TimeSpan.FromSeconds(5));
+                }
+                Assert.That(ml.IsHeldByCurrentThread, Is.True,
+                    "Lock should be re-acquired after ReleaseAcquire disposable is disposed.");
+            }
+        }
+
+        [Test]
+        public void MonitorSlimLock_TimeoutUnderContention_ThrowsTimeoutException()
+        {
+            var ml = new MonitorSlimLock(SmallTimeoutMs);
+            var holderReady = new ManualResetEventSlim(false);
+            var releaseHolder = new ManualResetEventSlim(false);
+
+            var holder = Task.Run(() =>
+            {
+                using (ml.Acquire())
+                {
+                    holderReady.Set();
+                    releaseHolder.Wait(TimeSpan.FromSeconds(10));
+                }
+            });
+
+            Assert.That(holderReady.Wait(TimeSpan.FromSeconds(5)), Is.True);
+            try
+            {
+                Assert.Throws<TimeoutException>(() => ml.Acquire());
+            }
+            finally
+            {
+                releaseHolder.Set();
+                holder.Wait(TimeSpan.FromSeconds(5));
+            }
+        }
+
+        // ── MonitorSpinLock (deprecated — smoke tests) ────────────────────────────────────
+
+        [Test]
+        public void MonitorSpinLock_BasicAcquireRelease_DoesNotThrow()
+        {
+            var ml = new MonitorSpinLock();
+            Assert.DoesNotThrow(() =>
+            {
+                using var d = ml.Acquire();
+            });
+        }
+
+        [Test]
+        public void MonitorSpinLock_AcquireWithTimeout_Succeeds()
+        {
+            var ml = new MonitorSpinLock();
+            Assert.DoesNotThrow(() =>
+            {
+                using var d = ml.Acquire(1000L);
+            });
+        }
+
+        [Test]
+        public void MonitorSpinLock_LockDepth_IsOneWhileHeld_ZeroAfterRelease()
+        {
+            var ml = new MonitorSpinLock();
+            using (ml.Acquire())
+            {
+                Assert.That(ml.LockDepth, Is.EqualTo(1));
+            }
+            Assert.That(ml.LockDepth, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void MonitorSpinLock_IsHeldByCurrentThread_TrueInsideFalseOutside()
+        {
+            var ml = new MonitorSpinLock();
+            Assert.That(ml.IsHeldByCurrentThread, Is.False);
+            using (ml.Acquire())
+            {
+                Assert.That(ml.IsHeldByCurrentThread, Is.True);
+            }
+            Assert.That(ml.IsHeldByCurrentThread, Is.False);
+        }
+
+        [Test]
+        public void MonitorSpinLock_Release_DoesNotThrow()
+        {
+            var ml = new MonitorSpinLock();
+            using (ml.Acquire())
+            {
+                Assert.DoesNotThrow(() => ml.Release());
+            }
+        }
+
+        [Test]
+        public void MonitorSpinLock_ReleaseAcquire_TemporarilyReleasesLock()
+        {
+            var ml = new MonitorSpinLock();
+            var otherThreadAcquired = new ManualResetEventSlim(false);
+
+            using (ml.Acquire())
+            {
+                using (ml.ReleaseAcquire())
+                {
+                    var task = Task.Run(() =>
+                    {
+                        using (ml.Acquire())
+                        {
+                            otherThreadAcquired.Set();
+                        }
+                    });
+                    Assert.That(otherThreadAcquired.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                        "Other thread should acquire the lock during ReleaseAcquire.");
+                    task.Wait(TimeSpan.FromSeconds(5));
+                }
+                Assert.That(ml.IsHeldByCurrentThread, Is.True,
+                    "Lock should be re-acquired after ReleaseAcquire disposable is disposed.");
+            }
+        }
+
+        [Test]
+        public void MonitorSpinLock_Reentrant_SameThread_DoesNotDeadlock()
+        {
+            var ml = new MonitorSpinLock();
+            using (ml.Acquire())
+            {
+                Assert.That(ml.LockDepth, Is.EqualTo(1));
+                using (ml.Acquire())
+                {
+                    Assert.That(ml.LockDepth, Is.EqualTo(2));
+                }
+                Assert.That(ml.LockDepth, Is.EqualTo(1));
+            }
+            Assert.That(ml.LockDepth, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void MonitorSpinLock_TimeoutUnderContention_ThrowsTimeoutException()
+        {
+            var ml = new MonitorSpinLock(SmallTimeoutMs);
+            var holderReady = new ManualResetEventSlim(false);
+            var releaseHolder = new ManualResetEventSlim(false);
+
+            var holder = Task.Run(() =>
+            {
+                using (ml.Acquire())
+                {
+                    holderReady.Set();
+                    releaseHolder.Wait(TimeSpan.FromSeconds(10));
+                }
+            });
+
+            Assert.That(holderReady.Wait(TimeSpan.FromSeconds(5)), Is.True);
+            try
+            {
+                Assert.Throws<TimeoutException>(() => ml.Acquire());
+            }
+            finally
+            {
+                releaseHolder.Set();
+                holder.Wait(TimeSpan.FromSeconds(5));
+            }
+        }
+    }
+}

--- a/tst/NEsper.Compat.Tests/compat/threading/locks/SlimLockTests.cs
+++ b/tst/NEsper.Compat.Tests/compat/threading/locks/SlimLockTests.cs
@@ -1,0 +1,236 @@
+// Copyright (C) 2006-2024 Esper Team. All rights reserved.
+// Subject to the terms of the GPL license (see license.txt).
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using com.espertech.esper.compat;
+using com.espertech.esper.compat.threading.locks;
+
+namespace com.espertech.esper.compat.threading.locks
+{
+    [TestFixture]
+    public class SlimLockTests
+    {
+        // ── Enter() / Release() ────────────────────────────────────────────────────────────
+
+        [Test]
+        public void Enter_Uncontested_AcquiresAndReleasesSuccessfully()
+        {
+            var sl = new SlimLock();
+            Assert.DoesNotThrow(() =>
+            {
+                sl.Enter();
+                sl.Release();
+            });
+        }
+
+        [Test]
+        public void Enter_Reentrant_SameThread_DepthTrackedCorrectly()
+        {
+            // SlimLock._myLockDepth is private; verify depth tracking behaviourally.
+            // Enter(timeout) from the SAME thread always succeeds (reentrancy path), so
+            // the contention check must come from a separate thread.
+            //
+            // Expected sequence:
+            //   depth 0 → Enter() → 1 → Enter() → 2
+            //   Release() → depth 1  — second thread still blocked
+            //   Release() → depth 0  — second thread can now acquire
+            var sl = new SlimLock();
+
+            sl.Enter(); // depth = 1
+            sl.Enter(); // depth = 2
+
+            sl.Release(); // depth = 1 — lock still owned by this thread
+
+            // From another thread: should NOT acquire while depth > 0
+            bool acquiredEarly = Task.Run(() => sl.Enter(50)).GetAwaiter().GetResult();
+            Assert.That(acquiredEarly, Is.False,
+                "Lock should still be held after only one Release() of two nested Enter() calls.");
+
+            sl.Release(); // depth = 0 — lock is now free
+
+            // From another thread: should now acquire and release from the same thread.
+            bool acquiredAfter = Task.Run(() =>
+            {
+                bool r = sl.Enter(1000);
+                if (r) sl.Release();
+                return r;
+            }).GetAwaiter().GetResult();
+            Assert.That(acquiredAfter, Is.True,
+                "Lock should be free after the second Release() brings depth to zero.");
+        }
+
+        // ── Enter(int timeout) ─────────────────────────────────────────────────────────────
+
+        [Test]
+        public void Enter_WithTimeout_Uncontested_ReturnsTrue()
+        {
+            var sl = new SlimLock();
+            bool acquired = sl.Enter(1000);
+            Assert.That(acquired, Is.True);
+            sl.Release();
+        }
+
+        [Test]
+        public void Enter_WithTimeout_ReentrantSameThread_ReturnsTrue()
+        {
+            var sl = new SlimLock();
+            bool first = sl.Enter(1000);
+            Assert.That(first, Is.True);
+            bool second = sl.Enter(1000);
+            Assert.That(second, Is.True);
+            sl.Release();
+            sl.Release();
+        }
+
+        [Test]
+        public void Enter_WithTimeout_UnderContention_AcquiresAfterHolderReleases()
+        {
+            var sl = new SlimLock();
+            var holderAcquired = new ManualResetEventSlim(false);
+            var releaseHolder = new ManualResetEventSlim(false);
+
+            var holderTask = Task.Run(() =>
+            {
+                sl.Enter();
+                holderAcquired.Set();
+                releaseHolder.Wait(TimeSpan.FromSeconds(10));
+                sl.Release();
+            });
+
+            Assert.That(holderAcquired.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+            bool acquired = false;
+            var waiterTask = Task.Run(() =>
+            {
+                acquired = sl.Enter(5000);
+                if (acquired) sl.Release();
+            });
+
+            Thread.Sleep(30);
+            releaseHolder.Set();
+            waiterTask.Wait(TimeSpan.FromSeconds(10));
+            holderTask.Wait(TimeSpan.FromSeconds(5));
+
+            Assert.That(acquired, Is.True, "Waiter should acquire the lock after holder releases.");
+        }
+
+        [Test]
+        public void Enter_WithTimeout_UnderContention_ReturnsFalseOnTimeout()
+        {
+            var sl = new SlimLock();
+            var holderAcquired = new ManualResetEventSlim(false);
+            var releaseHolder = new ManualResetEventSlim(false);
+
+            var holderTask = Task.Run(() =>
+            {
+                sl.Enter();
+                holderAcquired.Set();
+                releaseHolder.Wait(TimeSpan.FromSeconds(30));
+                sl.Release();
+            });
+
+            Assert.That(holderAcquired.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+            bool acquired = true;
+            try
+            {
+                acquired = sl.Enter(50);
+            }
+            finally
+            {
+                releaseHolder.Set();
+                holderTask.Wait(TimeSpan.FromSeconds(5));
+            }
+
+            Assert.That(acquired, Is.False, "Should return false when the lock cannot be acquired within timeout.");
+        }
+
+        // ── SmartWait(int) ─────────────────────────────────────────────────────────────────
+
+        [Test]
+        public void SmartWait_Iter1_DoesNotThrow()
+        {
+            Assert.DoesNotThrow(() => SlimLock.SmartWait(1));
+        }
+
+        [Test]
+        public void SmartWait_Iter15_DoesNotThrow()
+        {
+            Assert.DoesNotThrow(() => SlimLock.SmartWait(15));
+        }
+
+        [Test]
+        public void SmartWait_Iter45_DoesNotThrow()
+        {
+            Assert.DoesNotThrow(() => SlimLock.SmartWait(45));
+        }
+
+        [Test]
+        public void SmartWait_Iter75_DoesNotThrow()
+        {
+            Assert.DoesNotThrow(() => SlimLock.SmartWait(75));
+        }
+
+        [Test]
+        public void SmartWait_Iter110_DoesNotThrow()
+        {
+            Assert.DoesNotThrow(() => SlimLock.SmartWait(110));
+        }
+
+        // ── SmartWait(int, long) ───────────────────────────────────────────────────────────
+
+        [Test]
+        public void SmartWait_WithFutureTimeEnd_Iter1_ReturnsTrue()
+        {
+            long futureEnd = DateTimeHelper.CurrentTimeMillis + 60000L;
+            bool result = SlimLock.SmartWait(1, futureEnd);
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void SmartWait_WithFutureTimeEnd_Iter15_ReturnsTrue()
+        {
+            long futureEnd = DateTimeHelper.CurrentTimeMillis + 60000L;
+            bool result = SlimLock.SmartWait(15, futureEnd);
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void SmartWait_WithFutureTimeEnd_Iter45_ReturnsTrue()
+        {
+            long futureEnd = DateTimeHelper.CurrentTimeMillis + 60000L;
+            bool result = SlimLock.SmartWait(45, futureEnd);
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void SmartWait_WithFutureTimeEnd_Iter75_ReturnsTrue()
+        {
+            long futureEnd = DateTimeHelper.CurrentTimeMillis + 60000L;
+            bool result = SlimLock.SmartWait(75, futureEnd);
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void SmartWait_WithFutureTimeEnd_Iter110_ReturnsTrue()
+        {
+            long futureEnd = DateTimeHelper.CurrentTimeMillis + 60000L;
+            bool result = SlimLock.SmartWait(110, futureEnd);
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void SmartWait_WithExpiredTimeEnd_MultipleOf10GreaterThan60_ReturnsFalse()
+        {
+            // iter=70: multiple of 10, > 60 — triggers the deadline check
+            // timeEnd=0L is always in the past (epoch millis for the current time is ~1.7 trillion)
+            bool result = SlimLock.SmartWait(70, 0L);
+            Assert.That(result, Is.False);
+        }
+    }
+}

--- a/tst/NEsper.Compat.Tests/compat/threading/locks/SlimReaderWriterLockTests.cs
+++ b/tst/NEsper.Compat.Tests/compat/threading/locks/SlimReaderWriterLockTests.cs
@@ -1,0 +1,379 @@
+// Copyright (C) 2006-2024 Esper Team. All rights reserved.
+// Subject to the terms of the GPL license (see license.txt).
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using com.espertech.esper.compat.threading.locks;
+
+namespace com.espertech.esper.compat.threading.locks
+{
+    /// <summary>
+    /// Tests for Task 1.4: SlimReaderWriterLock and CommonReadLock share a single IDisposable
+    /// instance across all callers of AcquireReadLock() / Acquire().
+    ///
+    /// Because TrackedDisposable is idempotent (Task 1.1), the second Dispose() on the shared
+    /// instance is a no-op: the second reader's ExitReadLock() is never called, permanently
+    /// leaking the read lock.  A writer that subsequently tries to acquire will hang or time out.
+    ///
+    /// Root objects with the bug:
+    ///   SlimReaderWriterLock._rDisposable — returned by every AcquireReadLock() call
+    ///   SlimReaderWriterLock._wDisposable — returned by every AcquireWriteLock() call
+    ///   CommonReadLock._disposableObj     — returned by every Acquire() call via ReadLock
+    ///
+    /// FIX: remove the cached fields; return a new TrackedDisposable per acquisition.
+    ///
+    /// STATUS:
+    ///   "Distinct disposable" tests — FAIL NOW (same object returned)
+    ///   "Writer acquirable after both readers release" tests — FAIL NOW (writer times out)
+    ///   "Basic timeout/state" tests — PASS both before and after fix
+    /// </summary>
+    [TestFixture]
+    public class SlimReaderWriterLockTests
+    {
+        // ── Shared disposable: AcquireReadLock() (direct path) ──────────────────────────
+
+        [Test]
+        public void AcquireReadLock_ReturnsDistinctDisposablePerAcquisition()
+        {
+            // FAILS NOW: both calls return _rDisposable (the same cached instance).
+            // PASSES AFTER FIX: new TrackedDisposable per acquisition.
+            var rw = new SlimReaderWriterLock(LockConstants.DefaultTimeout);
+            var d1 = rw.AcquireReadLock();
+            var d2 = rw.AcquireReadLock();
+            try
+            {
+                Assert.That(d1, Is.Not.SameAs(d2),
+                    "Each AcquireReadLock() must return a distinct IDisposable. " +
+                    "A shared instance means the second Dispose() is a no-op, leaking the lock.");
+            }
+            finally
+            {
+                d1.Dispose();
+                d2.Dispose();
+            }
+        }
+
+        [Test]
+        public void AcquireWriteLock_ReturnsDistinctDisposablePerAcquisition()
+        {
+            // Write lock is exclusive so we acquire-release-acquire to obtain two handles.
+            // FAILS NOW: both calls return _wDisposable.
+            var rw = new SlimReaderWriterLock(LockConstants.DefaultTimeout);
+            var d1 = rw.AcquireWriteLock();
+            d1.Dispose();
+            var d2 = rw.AcquireWriteLock();
+            d2.Dispose();
+
+            Assert.That(d1, Is.Not.SameAs(d2),
+                "Each AcquireWriteLock() must return a distinct IDisposable.");
+        }
+
+        [Test]
+        public void AcquireWriteLock_TimeSpanOverload_ReturnsDistinctDisposable()
+        {
+            // FAILS NOW: the TimeSpan overload also returns _wDisposable.
+            var rw = new SlimReaderWriterLock(LockConstants.DefaultTimeout);
+            var span = TimeSpan.FromSeconds(5);
+            var d1 = rw.AcquireWriteLock(span);
+            d1.Dispose();
+            var d2 = rw.AcquireWriteLock(span);
+            d2.Dispose();
+
+            Assert.That(d1, Is.Not.SameAs(d2),
+                "AcquireWriteLock(TimeSpan) must also return a distinct IDisposable per call.");
+        }
+
+        // ── Shared disposable: correctness consequence (concurrent readers) ─────────────
+
+        [Test]
+        public void ConcurrentReaders_AfterBothRelease_WriterCanAcquire()
+        {
+            // BUG DEMONSTRATION:
+            //   Thread A and Thread B both call AcquireReadLock() and receive _rDisposable.
+            //   Thread A disposes → ExitReadLock() called once (count: 2→1), action nulled.
+            //   Thread B disposes → action is null → no-op → count stays at 1.
+            //   Writer tries to acquire → read count > 0 → TimeoutException.
+            //
+            // FAILS NOW: writer times out because read lock is permanently leaked.
+            // PASSES AFTER FIX: both readers properly release; writer acquires immediately.
+
+            const int writerTimeoutMs = 500;
+
+            var rw = new SlimReaderWriterLock(LockConstants.DefaultTimeout);
+            var reader1Ready = new ManualResetEventSlim(false);
+            var reader2Ready = new ManualResetEventSlim(false);
+            var readersCanRelease = new ManualResetEventSlim(false);
+
+            var t1 = Task.Run(() =>
+            {
+                using var d = rw.AcquireReadLock();
+                reader1Ready.Set();
+                readersCanRelease.Wait();
+            });
+
+            var t2 = Task.Run(() =>
+            {
+                using var d = rw.AcquireReadLock();
+                reader2Ready.Set();
+                readersCanRelease.Wait();
+            });
+
+            Assert.That(reader1Ready.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "Reader 1 failed to acquire lock in test setup.");
+            Assert.That(reader2Ready.Wait(TimeSpan.FromSeconds(5)), Is.True,
+                "Reader 2 failed to acquire lock in test setup.");
+
+            readersCanRelease.Set();
+            Task.WaitAll(new[] { t1, t2 }, TimeSpan.FromSeconds(5));
+
+            Assert.DoesNotThrow(
+                () =>
+                {
+                    using var w = rw.AcquireWriteLock(TimeSpan.FromMilliseconds(writerTimeoutMs));
+                },
+                $"Writer could not acquire after both readers released within {writerTimeoutMs} ms. " +
+                "The second reader's dispose was a no-op — its read lock was leaked.");
+        }
+
+        [Test]
+        public void ConcurrentReaders_DisposingFirstDoesNotRelaseSecond()
+        {
+            // Demonstrates the mechanism of the bug:
+            // After Thread A disposes _rDisposable, the underlying ReaderWriterLockSlim
+            // still has Thread B's read lock held.  A writer should NOT be able to acquire yet.
+            //
+            // FAILS NOW: read count is leaking in the opposite direction —
+            //   after reader 1 disposes (which nulls the action), reader 2's dispose is no-op,
+            //   so the count never reaches 0.  The writer actually WILL fail to acquire.
+            //   The test captures this by verifying reader 2 can still observe read-lock state
+            //   after reader 1 released — the LACK of interference in the other direction.
+            //
+            // This is a positive signal test: verifies readers are independent.
+
+            const int shortTimeoutMs = 100;
+
+            var rw = new SlimReaderWriterLock(LockConstants.DefaultTimeout);
+            var reader1HasLock = new ManualResetEventSlim(false);
+            var reader2HasLock = new ManualResetEventSlim(false);
+            var reader1CanRelease = new ManualResetEventSlim(false);
+            var reader1Released = new ManualResetEventSlim(false);
+            var reader2CanRelease = new ManualResetEventSlim(false);
+
+            var t1 = Task.Run(() =>
+            {
+                using var d = rw.AcquireReadLock();
+                reader1HasLock.Set();
+                reader1CanRelease.Wait();
+                // d disposed here
+            });
+            reader1HasLock.Wait(TimeSpan.FromSeconds(5));
+
+            var t2 = Task.Run(() =>
+            {
+                using var d = rw.AcquireReadLock();
+                reader2HasLock.Set();
+                reader2CanRelease.Wait();
+                // d disposed here
+            });
+            reader2HasLock.Wait(TimeSpan.FromSeconds(5));
+
+            // Release reader 1 only.
+            reader1CanRelease.Set();
+            t1.Wait(TimeSpan.FromSeconds(5));
+
+            // Reader 2 is still holding its lock.  A writer must NOT be able to acquire.
+            Assert.Throws<TimeoutException>(
+                () => rw.AcquireWriteLock(TimeSpan.FromMilliseconds(shortTimeoutMs)),
+                "Writer must be blocked while reader 2 still holds the lock.");
+
+            // Release reader 2.
+            reader2CanRelease.Set();
+            t2.Wait(TimeSpan.FromSeconds(5));
+
+            // Now writer must succeed.
+            Assert.DoesNotThrow(
+                () =>
+                {
+                    using var w = rw.AcquireWriteLock(TimeSpan.FromMilliseconds(500));
+                },
+                "Writer must succeed after both readers have released.");
+        }
+
+        // ── Shared disposable: CommonReadLock path (ReadLock.Acquire) ───────────────────
+
+        [Test]
+        public void CommonReadLock_AcquireReturnsDistinctDisposablePerCall()
+        {
+            // CommonReadLock._disposableObj is pre-created in the constructor and returned
+            // from every Acquire() call — the same bug via the ReadLock property.
+            //
+            // FAILS NOW: both calls return the same _disposableObj.
+            var rw = new SlimReaderWriterLock(LockConstants.DefaultTimeout);
+            var d1 = rw.ReadLock.Acquire();
+            var d2 = rw.ReadLock.Acquire();
+            try
+            {
+                Assert.That(d1, Is.Not.SameAs(d2),
+                    "CommonReadLock.Acquire() must return a distinct IDisposable per call.");
+            }
+            finally
+            {
+                d1.Dispose();
+                d2.Dispose();
+            }
+        }
+
+        [Test]
+        public void CommonReadLock_ConcurrentAcquires_BothReleaseProperly()
+        {
+            // Same as ConcurrentReaders_AfterBothRelease_WriterCanAcquire but via ReadLock.Acquire().
+            // FAILS NOW: second ReadLock.Acquire() dispose is a no-op.
+
+            const int writerTimeoutMs = 500;
+
+            var rw = new SlimReaderWriterLock(LockConstants.DefaultTimeout);
+            var reader1Ready = new ManualResetEventSlim(false);
+            var reader2Ready = new ManualResetEventSlim(false);
+            var readersCanRelease = new ManualResetEventSlim(false);
+
+            var t1 = Task.Run(() =>
+            {
+                using var d = rw.ReadLock.Acquire();
+                reader1Ready.Set();
+                readersCanRelease.Wait();
+            });
+
+            var t2 = Task.Run(() =>
+            {
+                using var d = rw.ReadLock.Acquire();
+                reader2Ready.Set();
+                readersCanRelease.Wait();
+            });
+
+            Assert.That(reader1Ready.Wait(TimeSpan.FromSeconds(5)), Is.True);
+            Assert.That(reader2Ready.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+            readersCanRelease.Set();
+            Task.WaitAll(new[] { t1, t2 }, TimeSpan.FromSeconds(5));
+
+            Assert.DoesNotThrow(
+                () =>
+                {
+                    using var w = rw.AcquireWriteLock(TimeSpan.FromMilliseconds(writerTimeoutMs));
+                },
+                "Writer could not acquire after both CommonReadLock holders released.");
+        }
+
+        // ── Non-bug correctness tests (PASS both before and after fix) ───────────────────
+
+        [Test]
+        public void AcquireReadLock_Succeeds_WhenNoContention()
+        {
+            var rw = new SlimReaderWriterLock(LockConstants.DefaultTimeout);
+            Assert.DoesNotThrow(() =>
+            {
+                using var r = rw.AcquireReadLock();
+            });
+        }
+
+        [Test]
+        public void AcquireWriteLock_Succeeds_WhenNoContention()
+        {
+            var rw = new SlimReaderWriterLock(LockConstants.DefaultTimeout);
+            Assert.DoesNotThrow(() =>
+            {
+                using var w = rw.AcquireWriteLock();
+            });
+        }
+
+        [Test]
+        public void AcquireReadLock_ThrowsTimeoutException_WhenWriterHeld()
+        {
+            var rw = new SlimReaderWriterLock(200); // 200 ms timeout
+            var writerAcquired = new ManualResetEventSlim(false);
+            var releaseWriter = new ManualResetEventSlim(false);
+
+            var writerTask = Task.Run(() =>
+            {
+                using var w = rw.AcquireWriteLock();
+                writerAcquired.Set();
+                releaseWriter.Wait(TimeSpan.FromSeconds(30));
+            });
+
+            Assert.That(writerAcquired.Wait(TimeSpan.FromSeconds(5)), Is.True);
+            try
+            {
+                Assert.Throws<TimeoutException>(() => rw.AcquireReadLock(),
+                    "Reader must time out while a writer holds the lock.");
+            }
+            finally
+            {
+                releaseWriter.Set();
+                writerTask.Wait(TimeSpan.FromSeconds(5));
+            }
+        }
+
+        [Test]
+        public void AcquireWriteLock_ThrowsTimeoutException_WhenReaderHeld()
+        {
+            var rw = new SlimReaderWriterLock(200);
+            var readerAcquired = new ManualResetEventSlim(false);
+            var releaseReader = new ManualResetEventSlim(false);
+
+            var readerTask = Task.Run(() =>
+            {
+                using var r = rw.AcquireReadLock();
+                readerAcquired.Set();
+                releaseReader.Wait(TimeSpan.FromSeconds(30));
+            });
+
+            Assert.That(readerAcquired.Wait(TimeSpan.FromSeconds(5)), Is.True);
+            try
+            {
+                Assert.Throws<TimeoutException>(() => rw.AcquireWriteLock(),
+                    "Writer must time out while a reader holds the lock.");
+            }
+            finally
+            {
+                releaseReader.Set();
+                readerTask.Wait(TimeSpan.FromSeconds(5));
+            }
+        }
+
+        [Test]
+        public void IsWriterLockHeld_ReflectsActualState()
+        {
+            var rw = new SlimReaderWriterLock(LockConstants.DefaultTimeout);
+
+            Assert.That(rw.IsWriterLockHeld, Is.False, "No lock held initially.");
+
+            using (rw.AcquireWriteLock())
+            {
+                Assert.That(rw.IsWriterLockHeld, Is.True, "Write lock is held.");
+            }
+
+            Assert.That(rw.IsWriterLockHeld, Is.False, "Write lock released after using block.");
+        }
+
+        [Test]
+        public void WriterBlocksReaderAndReaderBlocksWriter_Sequential()
+        {
+            var rw = new SlimReaderWriterLock(LockConstants.DefaultTimeout);
+
+            // Write then read
+            using (rw.AcquireWriteLock())
+            {
+                Assert.That(rw.IsWriterLockHeld, Is.True);
+            }
+
+            using (rw.AcquireReadLock())
+            {
+                Assert.That(rw.IsWriterLockHeld, Is.False);
+            }
+        }
+    }
+}

--- a/tst/NEsper.Compat.Tests/compat/threading/locks/StandardReaderWriterLockTests.cs
+++ b/tst/NEsper.Compat.Tests/compat/threading/locks/StandardReaderWriterLockTests.cs
@@ -1,0 +1,138 @@
+// Copyright (C) 2006-2024 Esper Team. All rights reserved.
+// Subject to the terms of the GPL license (see license.txt).
+
+#pragma warning disable CS0618
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using com.espertech.esper.compat.threading.locks;
+
+namespace com.espertech.esper.compat.threading.locks
+{
+    [TestFixture]
+    public class StandardReaderWriterLockTests
+    {
+        private const int LockTimeoutMs = 5000;
+        private const int SmallTimeoutMs = 150;
+
+        [Test]
+        public void AcquireReadLock_NoContention_Succeeds()
+        {
+            var rwl = new StandardReaderWriterLock(LockTimeoutMs);
+            Assert.DoesNotThrow(() =>
+            {
+                using var d = rwl.AcquireReadLock();
+            });
+        }
+
+        [Test]
+        public void AcquireWriteLock_NoContention_Succeeds()
+        {
+            var rwl = new StandardReaderWriterLock(LockTimeoutMs);
+            Assert.DoesNotThrow(() =>
+            {
+                using var d = rwl.AcquireWriteLock();
+            });
+        }
+
+        [Test]
+        public void AcquireWriteLock_WithTimeSpan_NoContention_Succeeds()
+        {
+            var rwl = new StandardReaderWriterLock(LockTimeoutMs);
+            Assert.DoesNotThrow(() =>
+            {
+                using var d = rwl.AcquireWriteLock(TimeSpan.FromSeconds(5));
+            });
+        }
+
+        [Test]
+        public void IsWriterLockHeld_FalseInitially()
+        {
+            var rwl = new StandardReaderWriterLock(LockTimeoutMs);
+            Assert.That(rwl.IsWriterLockHeld, Is.False);
+        }
+
+        [Test]
+        public void IsWriterLockHeld_TrueWhileWriteLockHeld_FalseAfterRelease()
+        {
+            var rwl = new StandardReaderWriterLock(LockTimeoutMs);
+            using (rwl.AcquireWriteLock())
+            {
+                Assert.That(rwl.IsWriterLockHeld, Is.True);
+            }
+            Assert.That(rwl.IsWriterLockHeld, Is.False);
+        }
+
+        [Test]
+        public void ReleaseWriteLock_ReleasesLock_SubsequentReaderSucceeds()
+        {
+            var rwl = new StandardReaderWriterLock(LockTimeoutMs);
+            rwl.WriteLock.Acquire();
+            Assert.DoesNotThrow(() => rwl.ReleaseWriteLock());
+            Assert.DoesNotThrow(() =>
+            {
+                using var r = rwl.AcquireReadLock();
+            });
+        }
+
+        [Test]
+        public void AcquireReadLock_WhileWriterHeld_ThrowsTimeoutException()
+        {
+            var rwl = new StandardReaderWriterLock(SmallTimeoutMs);
+            var writerReady = new ManualResetEventSlim(false);
+            var releaseWriter = new ManualResetEventSlim(false);
+
+            var writer = Task.Run(() =>
+            {
+                using (rwl.AcquireWriteLock())
+                {
+                    writerReady.Set();
+                    releaseWriter.Wait(TimeSpan.FromSeconds(10));
+                }
+            });
+
+            Assert.That(writerReady.Wait(TimeSpan.FromSeconds(5)), Is.True);
+            try
+            {
+                Assert.Throws<TimeoutException>(() => rwl.ReadLock.Acquire());
+            }
+            finally
+            {
+                releaseWriter.Set();
+                writer.Wait(TimeSpan.FromSeconds(5));
+            }
+        }
+
+        [Test]
+        public void AcquireWriteLock_WhileReaderHeld_ThrowsTimeoutException()
+        {
+            var rwl = new StandardReaderWriterLock(SmallTimeoutMs);
+            var readerReady = new ManualResetEventSlim(false);
+            var releaseReader = new ManualResetEventSlim(false);
+
+            var reader = Task.Run(() =>
+            {
+                using (rwl.AcquireReadLock())
+                {
+                    readerReady.Set();
+                    releaseReader.Wait(TimeSpan.FromSeconds(10));
+                }
+            });
+
+            Assert.That(readerReady.Wait(TimeSpan.FromSeconds(5)), Is.True);
+            try
+            {
+                Assert.Throws<TimeoutException>(() => rwl.WriteLock.Acquire());
+            }
+            finally
+            {
+                releaseReader.Set();
+                reader.Wait(TimeSpan.FromSeconds(5));
+            }
+        }
+    }
+}

--- a/tst/NEsper.Compat.Tests/compat/threading/locks/TelemetryTests.cs
+++ b/tst/NEsper.Compat.Tests/compat/threading/locks/TelemetryTests.cs
@@ -1,0 +1,273 @@
+// Copyright (C) 2006-2024 Esper Team. All rights reserved.
+// Subject to the terms of the GPL license (see license.txt).
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using com.espertech.esper.compat.threading.locks;
+
+namespace com.espertech.esper.compat.threading.locks
+{
+    [TestFixture]
+    public class TelemetryTests
+    {
+        // ── TelemetryLockCategory ─────────────────────────────────────────────────────────
+
+        [Test]
+        public void TelemetryLockCategory_Name_PreservesValue()
+        {
+            var cat = new TelemetryLockCategory("mycat");
+            Assert.That(cat.Name, Is.EqualTo("mycat"));
+        }
+
+        [Test]
+        public void TelemetryLockCategory_OnLockReleased_AddsToEvents()
+        {
+            var cat = new TelemetryLockCategory("test");
+            var e = new TelemetryEventArgs { Id = "1", RequestTime = 100, AcquireTime = 110, ReleaseTime = 120, StackTrace = new StackTrace() };
+            cat.OnLockReleased(this, e);
+            var events = cat.Events;
+            Assert.That(events, Has.Count.EqualTo(1));
+            Assert.That(events, Does.Contain(e));
+        }
+
+        [Test]
+        public void TelemetryLockCategory_Events_ThreadSafety_BothEventsRecorded()
+        {
+            var cat = new TelemetryLockCategory("concurrent");
+            var e1 = new TelemetryEventArgs { Id = "a", StackTrace = new StackTrace() };
+            var e2 = new TelemetryEventArgs { Id = "b", StackTrace = new StackTrace() };
+
+            var barrier = new Barrier(2);
+            var t1 = Task.Run(() => { barrier.SignalAndWait(); cat.OnLockReleased(this, e1); });
+            var t2 = Task.Run(() => { barrier.SignalAndWait(); cat.OnLockReleased(this, e2); });
+            Task.WaitAll(new[] { t1, t2 }, TimeSpan.FromSeconds(5));
+
+            var events = cat.Events;
+            Assert.That(events, Has.Count.EqualTo(2));
+        }
+
+        // ── TelemetryEngine ───────────────────────────────────────────────────────────────
+
+        [Test]
+        public void TelemetryEngine_GetCategory_New_ReturnsNonNullWithCorrectName()
+        {
+            var engine = new TelemetryEngine();
+            var cat = engine.GetCategory("alpha");
+            Assert.That(cat, Is.Not.Null);
+            Assert.That(cat.Name, Is.EqualTo("alpha"));
+        }
+
+        [Test]
+        public void TelemetryEngine_GetCategory_ExistingName_ReturnsSameInstance()
+        {
+            var engine = new TelemetryEngine();
+            var cat1 = engine.GetCategory("beta");
+            var cat2 = engine.GetCategory("beta");
+            Assert.That(cat1, Is.SameAs(cat2));
+        }
+
+        [Test]
+        public void TelemetryEngine_CategoryDictionary_ContainsAddedCategories()
+        {
+            var engine = new TelemetryEngine();
+            engine.GetCategory("x");
+            engine.GetCategory("y");
+            Assert.That(engine.CategoryDictionary, Does.ContainKey("x"));
+            Assert.That(engine.CategoryDictionary, Does.ContainKey("y"));
+        }
+
+        [Test]
+        public void TelemetryEngine_Categories_EnumeratesAllAdded()
+        {
+            var engine = new TelemetryEngine();
+            engine.GetCategory("p");
+            engine.GetCategory("q");
+            int count = 0;
+            foreach (var _ in engine.Categories)
+            {
+                count++;
+            }
+            Assert.That(count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void TelemetryEngine_DumpTo_WritesExpectedXmlElements()
+        {
+            var engine = new TelemetryEngine();
+            var cat = engine.GetCategory("myCategory");
+            var e = new TelemetryEventArgs
+            {
+                Id = "lock1",
+                RequestTime = 1000,
+                AcquireTime = 1010,
+                ReleaseTime = 2000,
+                StackTrace = new StackTrace()
+            };
+            cat.OnLockReleased(this, e);
+
+            using var sw = new StringWriter();
+            engine.DumpTo(sw);
+            string xml = sw.ToString();
+
+            Assert.That(xml, Does.Contain("telemetry"));
+            Assert.That(xml, Does.Contain("category"));
+            Assert.That(xml, Does.Contain("myCategory"));
+            Assert.That(xml, Does.Contain("event"));
+        }
+
+        // ── TelemetryLock ─────────────────────────────────────────────────────────────────
+
+        [Test]
+        public void TelemetryLock_Acquire_NoListener_DoesNotThrow()
+        {
+            var inner = new MonitorLock();
+            var tl = new TelemetryLock(inner);
+            Assert.DoesNotThrow(() =>
+            {
+                using var d = tl.Acquire();
+            });
+        }
+
+        [Test]
+        public void TelemetryLock_Acquire_WithListener_FiresLockReleasedEventOnDispose()
+        {
+            var inner = new MonitorLock();
+            var tl = new TelemetryLock("mylock", inner);
+            TelemetryEventArgs captured = null;
+            tl.LockReleased += (s, e) => captured = e;
+
+            using (tl.Acquire())
+            {
+            }
+
+            Assert.That(captured, Is.Not.Null, "LockReleased should have fired.");
+            Assert.That(captured.Id, Is.EqualTo("mylock"));
+            Assert.That(captured.RequestTime, Is.GreaterThan(0));
+            Assert.That(captured.AcquireTime, Is.GreaterThanOrEqualTo(captured.RequestTime));
+            Assert.That(captured.ReleaseTime, Is.GreaterThanOrEqualTo(captured.AcquireTime));
+        }
+
+        [Test]
+        public void TelemetryLock_AcquireWithTimeout_WithListener_FiresEvent()
+        {
+            var inner = new MonitorLock();
+            var tl = new TelemetryLock(inner);
+            bool fired = false;
+            tl.LockReleased += (s, e) => fired = true;
+
+            using (tl.Acquire(1000L))
+            {
+            }
+
+            Assert.That(fired, Is.True);
+        }
+
+        [Test]
+        public void TelemetryLock_ReleaseAcquire_FiresEvent()
+        {
+            var inner = new MonitorLock();
+            var tl = new TelemetryLock(inner);
+            bool fired = false;
+            tl.LockReleased += (s, e) => fired = true;
+
+            using (tl.Acquire())
+            {
+                using (tl.ReleaseAcquire())
+                {
+                }
+            }
+
+            Assert.That(fired, Is.True);
+        }
+
+        [Test]
+        public void TelemetryLock_Release_DoesNotThrow()
+        {
+            var inner = new MonitorLock();
+            var tl = new TelemetryLock(inner);
+            using (inner.Acquire())
+            {
+                Assert.DoesNotThrow(() => tl.Release());
+            }
+        }
+
+        // ── TelemetryReaderWriterLock ─────────────────────────────────────────────────────
+
+        [Test]
+        public void TelemetryReaderWriterLock_AcquireReadLock_FiresReadLockReleasedEvent()
+        {
+            var inner = new SlimReaderWriterLock(5000);
+            var trl = new TelemetryReaderWriterLock(inner);
+            bool fired = false;
+            trl.ReadLockReleased += (s, e) => fired = true;
+
+            using (trl.AcquireReadLock())
+            {
+            }
+
+            Assert.That(fired, Is.True, "ReadLockReleased should have fired.");
+        }
+
+        [Test]
+        public void TelemetryReaderWriterLock_AcquireWriteLock_FiresWriteLockReleasedEvent()
+        {
+            var inner = new SlimReaderWriterLock(5000);
+            var trl = new TelemetryReaderWriterLock(inner);
+            bool fired = false;
+            trl.WriteLockReleased += (s, e) => fired = true;
+
+            using (trl.AcquireWriteLock())
+            {
+            }
+
+            Assert.That(fired, Is.True, "WriteLockReleased should have fired.");
+        }
+
+        [Test]
+        public void TelemetryReaderWriterLock_AcquireWriteLockWithTimeSpan_FiresWriteLockReleasedEvent()
+        {
+            var inner = new SlimReaderWriterLock(5000);
+            var trl = new TelemetryReaderWriterLock(inner);
+            bool fired = false;
+            trl.WriteLockReleased += (s, e) => fired = true;
+
+            using (trl.AcquireWriteLock(TimeSpan.FromSeconds(5)))
+            {
+            }
+
+            Assert.That(fired, Is.True);
+        }
+
+        [Test]
+        public void TelemetryReaderWriterLock_IsWriterLockHeld_DelegatesToSubLock()
+        {
+            var inner = new SlimReaderWriterLock(5000);
+            var trl = new TelemetryReaderWriterLock(inner);
+
+            Assert.That(trl.IsWriterLockHeld, Is.False);
+            using (inner.AcquireWriteLock())
+            {
+                Assert.That(inner.IsWriterLockHeld, Is.True);
+            }
+        }
+
+        [Test]
+        public void TelemetryReaderWriterLock_ReleaseWriteLock_AllowsSubsequentReader()
+        {
+            var inner = new SlimReaderWriterLock(5000);
+            var trl = new TelemetryReaderWriterLock(inner);
+            trl.WriteLock.Acquire();
+            Assert.DoesNotThrow(() => trl.ReleaseWriteLock());
+            Assert.DoesNotThrow(() =>
+            {
+                using var r = trl.AcquireReadLock();
+            });
+        }
+    }
+}

--- a/tst/NEsper.Compat.Tests/compat/threading/locks/VoidAndDummyLockTests.cs
+++ b/tst/NEsper.Compat.Tests/compat/threading/locks/VoidAndDummyLockTests.cs
@@ -1,0 +1,194 @@
+// Copyright (C) 2006-2024 Esper Team. All rights reserved.
+// Subject to the terms of the GPL license (see license.txt).
+
+using System;
+
+using NUnit.Framework;
+
+using com.espertech.esper.compat.threading.locks;
+
+namespace com.espertech.esper.compat.threading.locks
+{
+    [TestFixture]
+    public class VoidAndDummyLockTests
+    {
+        // ── VoidLock ─────────────────────────────────────────────────────────────────────
+
+        [Test]
+        public void VoidLock_Acquire_ReturnsNonNullDisposable()
+        {
+            var vl = new VoidLock();
+            var d = vl.Acquire();
+            Assert.That(d, Is.Not.Null);
+        }
+
+        [Test]
+        public void VoidLock_AcquireDispose_DoesNotThrow()
+        {
+            var vl = new VoidLock();
+            Assert.DoesNotThrow(() =>
+            {
+                using var d = vl.Acquire();
+            });
+        }
+
+        [Test]
+        public void VoidLock_AcquireWithTimeout_ReturnsNonNullDisposable()
+        {
+            var vl = new VoidLock();
+            var d = vl.Acquire(1000L);
+            Assert.That(d, Is.Not.Null);
+        }
+
+        [Test]
+        public void VoidLock_AcquireWithTimeout_DoesNotThrow()
+        {
+            var vl = new VoidLock();
+            Assert.DoesNotThrow(() =>
+            {
+                using var d = vl.Acquire(500L);
+            });
+        }
+
+        [Test]
+        public void VoidLock_ReleaseAcquire_ReturnsNonNullDisposable()
+        {
+            var vl = new VoidLock();
+            var d = vl.ReleaseAcquire();
+            Assert.That(d, Is.Not.Null);
+        }
+
+        [Test]
+        public void VoidLock_Release_DoesNotThrow()
+        {
+            var vl = new VoidLock();
+            Assert.DoesNotThrow(() => vl.Release());
+        }
+
+        // ── VoidReaderWriterLock ──────────────────────────────────────────────────────────
+
+        [Test]
+        public void VoidReaderWriterLock_ReadLock_IsNotNull()
+        {
+            var vrwl = new VoidReaderWriterLock();
+            Assert.That(vrwl.ReadLock, Is.Not.Null);
+        }
+
+        [Test]
+        public void VoidReaderWriterLock_WriteLock_IsNotNull()
+        {
+            var vrwl = new VoidReaderWriterLock();
+            Assert.That(vrwl.WriteLock, Is.Not.Null);
+        }
+
+        [Test]
+        public void VoidReaderWriterLock_ReadLockAndWriteLock_AreSameInstance()
+        {
+            var vrwl = new VoidReaderWriterLock();
+            Assert.That(vrwl.ReadLock, Is.SameAs(vrwl.WriteLock));
+        }
+
+        [Test]
+        public void VoidReaderWriterLock_AcquireReadLock_ReturnsNonNull()
+        {
+            var vrwl = new VoidReaderWriterLock();
+            using var d = vrwl.AcquireReadLock();
+            Assert.That(d, Is.Not.Null);
+        }
+
+        [Test]
+        public void VoidReaderWriterLock_AcquireWriteLock_ReturnsNonNull()
+        {
+            var vrwl = new VoidReaderWriterLock();
+            using var d = vrwl.AcquireWriteLock();
+            Assert.That(d, Is.Not.Null);
+        }
+
+        [Test]
+        public void VoidReaderWriterLock_AcquireWriteLockWithTimeSpan_ReturnsNonNull()
+        {
+            var vrwl = new VoidReaderWriterLock();
+            using var d = vrwl.AcquireWriteLock(TimeSpan.FromSeconds(1));
+            Assert.That(d, Is.Not.Null);
+        }
+
+        [Test]
+        public void VoidReaderWriterLock_ReleaseWriteLock_DoesNotThrow()
+        {
+            var vrwl = new VoidReaderWriterLock();
+            Assert.DoesNotThrow(() => vrwl.ReleaseWriteLock());
+        }
+
+        [Test]
+        public void VoidReaderWriterLock_IsWriterLockHeld_AlwaysFalse()
+        {
+            var vrwl = new VoidReaderWriterLock();
+            Assert.That(vrwl.IsWriterLockHeld, Is.False);
+            using (vrwl.AcquireWriteLock())
+            {
+                Assert.That(vrwl.IsWriterLockHeld, Is.False);
+            }
+        }
+
+        // ── DummyReaderWriterLock ─────────────────────────────────────────────────────────
+
+        [Test]
+        public void DummyReaderWriterLock_ReadLock_IsNotNull()
+        {
+            var dummy = new DummyReaderWriterLock();
+            Assert.That(dummy.ReadLock, Is.Not.Null);
+        }
+
+        [Test]
+        public void DummyReaderWriterLock_WriteLock_IsNotNull()
+        {
+            var dummy = new DummyReaderWriterLock();
+            Assert.That(dummy.WriteLock, Is.Not.Null);
+        }
+
+        [Test]
+        public void DummyReaderWriterLock_ReadLockAndWriteLock_AreSameInstance()
+        {
+            var dummy = new DummyReaderWriterLock();
+            Assert.That(dummy.ReadLock, Is.SameAs(dummy.WriteLock));
+        }
+
+        [Test]
+        public void DummyReaderWriterLock_AcquireReadLock_ReturnsNonNull()
+        {
+            var dummy = new DummyReaderWriterLock();
+            using var d = dummy.AcquireReadLock();
+            Assert.That(d, Is.Not.Null);
+        }
+
+        [Test]
+        public void DummyReaderWriterLock_AcquireWriteLock_ReturnsNonNull()
+        {
+            var dummy = new DummyReaderWriterLock();
+            using var d = dummy.AcquireWriteLock();
+            Assert.That(d, Is.Not.Null);
+        }
+
+        [Test]
+        public void DummyReaderWriterLock_AcquireWriteLockWithTimeSpan_ReturnsNonNull()
+        {
+            var dummy = new DummyReaderWriterLock();
+            using var d = dummy.AcquireWriteLock(TimeSpan.FromSeconds(1));
+            Assert.That(d, Is.Not.Null);
+        }
+
+        [Test]
+        public void DummyReaderWriterLock_ReleaseWriteLock_DoesNotThrow()
+        {
+            var dummy = new DummyReaderWriterLock();
+            Assert.DoesNotThrow(() => dummy.ReleaseWriteLock());
+        }
+
+        [Test]
+        public void DummyReaderWriterLock_IsWriterLockHeld_AlwaysFalse()
+        {
+            var dummy = new DummyReaderWriterLock();
+            Assert.That(dummy.IsWriterLockHeld, Is.False);
+        }
+    }
+}

--- a/tst/NEsper.Regression/suite/multithread/MultithreadViewTimeWindowSceneTwo.cs
+++ b/tst/NEsper.Regression/suite/multithread/MultithreadViewTimeWindowSceneTwo.cs
@@ -129,7 +129,7 @@ namespace com.espertech.esper.regressionlib.suite.multithread
 
             // Create threads to send events
             var runnables = new TimeWinRunnable[threads.Length];
-            var @lock = new MonitorSpinLock();
+            var @lock = new MonitorSlimLock();
             for (var i = 0; i < threads.Length; i++) {
                 runnables[i] = new TimeWinRunnable(i, env, @lock, symbols, numEvents);
                 threads[i] = new Thread(runnables[i].Run) {


### PR DESCRIPTION
1. Refactored locking primitives (CommonReadLock, CommonWriteLock, MonitorLock, MonitorSlimLock, MonitorSpinLock, FairReaderWriterLock, FifoReaderWriterLock, SlimReaderWriterLock, TelemetryLock, TelemetryReaderWriterLock, VoidLock, ILockable) — reduced dead surface, tightened contracts.
2. Updated DefaultLockManager and DefaultReaderWriterLockManager to align with revised lock interfaces.
3. Added comprehensive unit tests for all lock types: CommonLockTests, DefaultLockManagerTests, DefaultReaderWriterLockManagerTests, FairReaderWriterLockTests, FifoReaderWriterLockTests, MonitorLockTests, SlimLockTests, SlimReaderWriterLockTests, StandardReaderWriterLockTests, TelemetryTests, VoidAndDummyLockTests, LockableExtensionsTests, TrackedDisposableTests.
4. Minor compat fixes: TrackedDisposable, BoundBlockingQueue, MagicMarker, MagicStringDictionaryExtensions, MagicType.
5. Updated StatementCPCacheService and ManagedReadWriteLock to use revised locks.
6. Fixed MultithreadViewTimeWindowSceneTwo test.
7. ThreadPoolExecutor minor update in benchmark project.
8. Added GitHub Actions regression-tests workflow: parallel matrix of 16 batches, single build artifact shared across all jobs, postgres service container, dorny/test-reporter summary, workflow_dispatch with optional single-batch input.
9. Added requiresDatabase flag to all batches in test-batches.json.
10. Extended run-test-batches.ps1 with additional batch support.